### PR TITLE
Enable buildbot for ANSI coverage via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ install:
   - curl -L https://raw.githubusercontent.com/snmsts/roswell/release/scripts/install-for-ci.sh | sh
   - ros install prove
 
+# TODO: do this without PROVE via ASDF prescriptions
 script:
-  - ros -s prove -e '(or (prove:run :quri-test) (uiop:quit -1))'
+  - ros -s prove -e '(or (prove:run :emotiq-tests) (uiop:quit -1))'
   - run-prove quri-test.asd
   - ros -s prove -s cl-coveralls
         -e '(or (coveralls:with-coveralls (:exclude (list "t"))

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: common-lisp
+# Attempt to run as more efficient container
+sudo: false
+
+env:
+  global:
+    - PATH=~/.roswell/bin:$PATH
+    - ROSWELL_INSTALL_DIR=$HOME/.roswell
+  matrix:
+    - LISP=sbcl-bin
+    - LISP=ccl-bin
+    - LISP=abcl-bin
+    - LISP=ecl-bin
+    - LISP=clisp-bin
+
+install:
+  - curl -L https://raw.githubusercontent.com/snmsts/roswell/release/scripts/install-for-ci.sh | sh
+  - ros install prove
+
+script:
+  - ros -s prove -e '(or (prove:run :quri-test) (uiop:quit -1))'
+  - run-prove quri-test.asd
+  - ros -s prove -s cl-coveralls
+        -e '(or (coveralls:with-coveralls (:exclude (list "t"))
+                  (prove:run :quri-test))
+                (uiop:quit -1))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,9 @@ install:
   - curl -L https://raw.githubusercontent.com/snmsts/roswell/release/scripts/install-for-ci.sh | sh
   - ros install prove
 
-# TODO: do this without PROVE via ASDF prescriptions
 script:
-  - ros -s prove -e '(or (prove:run :emotiq-tests) (uiop:quit -1))'
-  - run-prove quri-test.asd
+  - ros -s prove -e '(or (prove:run :emotiq/t) (uiop:quit -1))'
   - ros -s prove -s cl-coveralls
         -e '(or (coveralls:with-coveralls (:exclude (list "t"))
-                  (prove:run :quri-test))
+                  (prove:run :emotiq/t))
                 (uiop:quit -1))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - LISP=ccl-bin
     - LISP=abcl-bin
     - LISP=ecl
-    - LISP=clisp-bin
+    - LISP=clisp
     - LISP=clasp
 
 install:
@@ -20,6 +20,7 @@ install:
 
 script:
   - ros -s prove -e '(or (prove:run :emotiq/t) (uiop:quit -1))'
+  - ros -s prove -e '(or (prove:run :cosi/t) (uiop:quit -1))'
   - ros -s prove -s cl-coveralls
         -e '(or (coveralls:with-coveralls (:exclude (list "t"))
                   (prove:run :emotiq/t))

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ env:
     - LISP=sbcl-bin
     - LISP=ccl-bin
     - LISP=abcl-bin
-    - LISP=ecl-bin
+    - LISP=ecl
     - LISP=clisp-bin
+    - LISP=clasp
 
 install:
   - curl -L https://raw.githubusercontent.com/snmsts/roswell/release/scripts/install-for-ci.sh | sh

--- a/src/Actors/futures.lisp
+++ b/src/Actors/futures.lisp
@@ -109,7 +109,9 @@ THE SOFTWARE.
   `(cdr (cell ,ref)))
 
 ;; ------------------------------------
-                   
+
+
+;;; FIXME (ccl) Don't know how to do conditional store to (CELL-CASFLAG REF)
 (defun forcer (ref evalfn valfn)
   ;; FORCER - a generalized forcing function
   ;;

--- a/src/Actors/futures.lisp
+++ b/src/Actors/futures.lisp
@@ -111,7 +111,12 @@ THE SOFTWARE.
 ;; ------------------------------------
 
 
+
 ;;; FIXME (ccl) Don't know how to do conditional store to (CELL-CASFLAG REF)
+#+(or ccl)
+(defun forcer (ref evalfn valfn)
+  (warn "Unimplemented forcer (ref evalfn valfn) under ccl."))
+#-(or ccl)  
 (defun forcer (ref evalfn valfn)
   ;; FORCER - a generalized forcing function
   ;;

--- a/src/Cosi/confidential-purchase.lisp
+++ b/src/Cosi/confidential-purchase.lisp
@@ -26,35 +26,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 |#
 
-(defpackage :crypto-purchase
-  (:use :common-lisp :crypto-mod-math)
-  (:import-from :edwards-ecc
-   :ed-mul
-   :ed-add
-   :ed-sub
-   :ed-div
-   :ed-negate
-   :ed-affine
-   :*edcurve*
-   :*ed-r*
-   :*ed-q*
-   :*ed-gen*
-   :ed-curve-name
-   :random-between
-   :ed-pt=
-   :ed-compress-pt
-   :ed-decompress-pt
-   :convert-bytes-to-int
-   :with-ed-curve
-   :ed-nth-pt
-   :ed-random-pair
-   )
-  (:import-from :ecc-crypto-b571
-   :convert-int-to-nbytesv
-   :convert-bytes-to-int)
-  (:export
-   ))
-
 (in-package :crypto-purchase)
 
 

--- a/src/Cosi/cosi-construction.lisp
+++ b/src/Cosi/cosi-construction.lisp
@@ -27,51 +27,6 @@ THE SOFTWARE.
 |#
 
 
-(defpackage :cosi-simgen
-  (:use :common-lisp :cosi :crypto-mod-math)
-  (:import-from :edwards-ecc
-   :ed-add 
-   :ed-sub 
-   :ed-mul 
-   :ed-div 
-   :ed-affine
-   :ed-nth-pt
-   :*ed-r*
-   :*ed-q*
-   :ed-neutral-point
-   :ed-pt=
-   :with-ed-curve
-   :ed-compress-pt
-   :ed-decompress-pt
-   :ed-validate-point
-   :ed-hash
-   :ed-random-pair)
-  (:import-from :ecc-crypto-b571
-   :random-between
-   :convert-int-to-nbytesv
-   :convert-bytes-to-int)
-  (:import-from :actors
-   :=bind
-   :=values
-   :=defun
-   :=lambda
-   :=funcall
-   :=apply
-   :pmapcar
-   :spawn
-   :current-actor
-   :recv
-   :become
-   :do-nothing
-   :make-actor
-   :set-executive-pool
-   :with-borrowed-mailbox
-   :pr)
-  (:export
-   :generate-tree
-   :reconstruct-tree
-   :forwarding))
-
 (in-package :cosi-simgen)
 
 (declaim (optimize (debug 3)))

--- a/src/Cosi/cosi-keying.lisp
+++ b/src/Cosi/cosi-keying.lisp
@@ -119,6 +119,7 @@ THE SOFTWARE.
                   ;; full 512 bits
                   (ed-convert-int-to-lev skey))))
          (a     0)
+         ;; the constant 3 is for cofactors of 8 or lower pow2
          (bits  (byte (- *ed-nbits* 5) 3)))
     (setf (ldb bits a) (ldb bits h)
           (ldb (byte 1 (1- *ed-nbits*)) a) 1)

--- a/src/Cosi/cosi-sockets.lisp
+++ b/src/Cosi/cosi-sockets.lisp
@@ -36,6 +36,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 |#
 
+#+:ALLEGRO (require :sock)
+
 
 (in-package :cosi-simgen)
 

--- a/src/Cosi/cosi.asd
+++ b/src/Cosi/cosi.asd
@@ -29,9 +29,8 @@ THE SOFTWARE.
 
 (in-package :cl-user)
 
-#+:ALLEGRO (require :sock)
 
-(asdf:defsystem "cosi"
+(defsystem "cosi"
   :description "Cosi: Authenticated multi-signatures in Lisp"
   :version     "1.0"
   :author      "D.McClain <dbm@emotiq.ch>"

--- a/src/Cosi/cosi.asd
+++ b/src/Cosi/cosi.asd
@@ -52,6 +52,17 @@ THE SOFTWARE.
                                      (:file "random-partition")
                                      (:file "range-proofs")))))
 
+
+(defsystem "cosi/test/allegro"
+  :description "Allegro timing code from dbm."
+  :depends-on (cosi)
+  :components ((:module source
+                        :pathname "./"
+                        :components ((:file "test-cas")))))
+                        
+
+
+
 (defsystem "cosi/t"
   :defsystem-depends-on (prove-asdf)
   :depends-on (prove cosi)

--- a/src/Cosi/cosi.asd
+++ b/src/Cosi/cosi.asd
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 (defsystem "cosi"
   :description "Cosi: Authenticated multi-signatures in Lisp"
-  :version     "1.0"
+  :version     "1.0.1"
   :author      "D.McClain <dbm@emotiq.ch>"
   :license     "Copyright (c) 2018 by Emotiq, A.G. MIT License."
   :depends-on (ironclad
@@ -53,7 +53,6 @@ THE SOFTWARE.
                                      (:file "cosi-keying")
 
                                      (:file "cosi-sockets")
-                                     
 
                                      (:file "random-partition")
                                      (:file "range-proofs")))))
@@ -67,8 +66,6 @@ THE SOFTWARE.
                         :components ((:file "test-cas")))))
                         
 
-
-
 (defsystem "cosi/t"
   :defsystem-depends-on (prove-asdf)
   :depends-on (prove cosi)
@@ -76,5 +73,6 @@ THE SOFTWARE.
               (uiop:symbol-call :prove-asdf :run-test-system c))
   :components ((:module range
                         :pathname "t/"
-                        :components ((:test-file "ranges-timing")))))
+                        :components ((:test-file "base")
+                                     (:test-file "ranges-timing")))))
 

--- a/src/Cosi/cosi.asd
+++ b/src/Cosi/cosi.asd
@@ -1,10 +1,6 @@
-;; ads.asd -- ASD File for Authenticated Data Structures
-;;
-;; DM/Emotiq  01/18
-;; -----------------------------------------------------------
-#|
-The MIT License
+;; cosi.asd -- ASDF File for Cosigning
 
+#|
 Copyright (c) 2018 Emotiq AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/Cosi/cosi.asd
+++ b/src/Cosi/cosi.asd
@@ -1,4 +1,5 @@
-;; cosi.asd -- ASDF File for Cosigning
+;;; -*- Mode: LISP; Syntax: COMMON-LISP -*-
+;;;; cosi.asd -- ASDF File for Cosigning
 
 #|
 Copyright (c) 2018 Emotiq AG
@@ -22,39 +23,41 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 |#
 
-
-(in-package :cl-user)
-
-
 (defsystem "cosi"
   :description "Cosi: Authenticated multi-signatures in Lisp"
   :version     "1.0"
   :author      "D.McClain <dbm@emotiq.ch>"
-  :license     "Copyright (c) 2018 by Emotiq, A.G. License terms apply."
-  :components  (
-		(:file "cosi-async")
+  :license     "Copyright (c) 2018 by Emotiq, A.G. MIT License."
+  :depends-on (ironclad
+               actors
+               core-crypto
+               lisp-object-encoder
+               useful-macros
+               usocket)
+  :in-order-to ((test-op (test-op "cosi/t")))
+  :components ((:module source
+                        :pathname "./"
+                        :serial t
+                        :components ((:file "cosi-async")
+                                     (:file "cosi")
+                                     (:file "cosi-sockets")
+                                     
+                                     (:file "cosi-construction")
+                                     (:file "cosi-handlers")
+                                     
+                                     (:file "confidential-purchase")
+                                     
+                                     (:file "cosi-keying")
 
-                ;; (:file "cosi")
-		;; (:file "tst-cas")
-                ;; (:file "cosi-socket")
+                                     (:file "random-partition")
+                                     (:file "range-proofs")))))
 
-                (:file "cosi-construction")
-                (:file "cosi-sockets")
-                (:file "cosi-handlers")
-
-                (:file "range-proofs")
-                (:file "confidential-purchase")
-
-                (:file "cosi-keying")
-                
-                ;; (:file :random-partition)
-                )
-  :SERIAL T
-  :depends-on   (:ironclad
-		 :actors
-                 :core-crypto
-                 :lisp-object-encoder
-                 :useful-macros
-                 :usocket
-                 ))
+(defsystem "cosi/t"
+  :defsystem-depends-on (prove-asdf)
+  :depends-on (prove cosi)
+  :perform (test-op (o c)
+              (uiop:symbol-call :prove-asdf :run-test-system c))
+  :components ((:module range
+                        :pathname "t/"
+                        :components ((:test-file "ranges-timing")))))
 

--- a/src/Cosi/cosi.asd
+++ b/src/Cosi/cosi.asd
@@ -35,12 +35,15 @@ THE SOFTWARE.
                useful-macros
                usocket)
   :in-order-to ((test-op (test-op "cosi/t")))
-  :components ((:module source
+  :components ((:module package
+                        :pathname "./"
+                        :components ((:file "package")))
+               (:module source
+                        :depends-on (package)
                         :pathname "./"
                         :serial t
                         :components ((:file "cosi-async")
                                      (:file "cosi")
-                                     (:file "cosi-sockets")
                                      
                                      (:file "cosi-construction")
                                      (:file "cosi-handlers")
@@ -48,6 +51,9 @@ THE SOFTWARE.
                                      (:file "confidential-purchase")
                                      
                                      (:file "cosi-keying")
+
+                                     (:file "cosi-sockets")
+                                     
 
                                      (:file "random-partition")
                                      (:file "range-proofs")))))

--- a/src/Cosi/cosi.lisp
+++ b/src/Cosi/cosi.lisp
@@ -3,33 +3,6 @@
 ;; DM/Emotiq  01/18
 ;; ------------------------------------------------------------------------
 
-(defpackage :cosi
-  (:use :common-lisp :crypto-mod-math)
-  (:import-from :edwards-ecc
-		:ed-add 
-		:ed-sub 
-		:ed-mul 
-		:ed-div 
-		:ed-affine
-		:ed-nth-pt
-		:*ed-r*
-		:*ed-q*
-                :ed-neutral-point
-                :ed-pt=
-		:with-ed-curve
-		:ed-compress-pt
-		:ed-decompress-pt
-		:ed-validate-point
-		:ed-hash
-		:ed-random-pair)
-  (:import-from :ecc-crypto-b571
-		:convert-int-to-nbytesv
-		:convert-bytes-to-int)
-  (:export
-   :schnorr-signature
-   :verify-schnorr-signature
-   ))
-
 ;; -------------------------------------------------------
 
 (in-package :cosi)

--- a/src/Cosi/package.lisp
+++ b/src/Cosi/package.lisp
@@ -1,0 +1,182 @@
+
+
+(defpackage :cosi
+  (:use :common-lisp :crypto-mod-math)
+  (:import-from :edwards-ecc
+		:ed-add 
+		:ed-sub 
+		:ed-mul 
+		:ed-div 
+		:ed-affine
+		:ed-nth-pt
+		:*ed-r*
+		:*ed-q*
+                :ed-neutral-point
+                :ed-pt=
+		:with-ed-curve
+		:ed-compress-pt
+		:ed-decompress-pt
+		:ed-validate-point
+		:ed-hash
+		:ed-random-pair)
+  (:import-from :ecc-crypto-b571
+		:convert-int-to-nbytesv)
+  #+(or) ;; DBM: which symbol should we be calling here? -- MTE
+  (:shadowing-import-from :ecc-crypto-b571
+		:convert-bytes-to-int)
+  (:export
+   :schnorr-signature
+   :verify-schnorr-signature))
+
+(defpackage :range-proofs
+  (:use :common-lisp :crypto-mod-math)
+  (:import-from :edwards-ecc
+   :ed-mul
+   :ed-add
+   :ed-sub
+   :ed-div
+   :ed-negate
+   :ed-affine
+   :*edcurve*
+   :*ed-r*
+   :*ed-q*
+   :*ed-gen*
+   :ed-curve-name
+   :random-between
+   :ed-pt=
+   :ed-compress-pt
+   :ed-decompress-pt
+   :with-ed-curve
+   :ed-nth-pt
+   :ed-random-pair)
+  (:import-from :ecc-crypto-b571
+   :convert-int-to-nbytesv
+   :convert-bytes-to-int)
+  (:export
+   :make-range-proofs
+   :validate-range-proof
+   :make-range-prover
+   :range-proof-block))
+
+
+(defpackage :crypto-purchase
+  (:use :common-lisp :crypto-mod-math)
+  (:import-from :edwards-ecc
+   :ed-mul
+   :ed-add
+   :ed-sub
+   :ed-div
+   :ed-negate
+   :ed-affine
+   :*edcurve*
+   :*ed-r*
+   :*ed-q*
+   :*ed-gen*
+   :ed-curve-name
+   :random-between
+   :ed-pt=
+   :ed-compress-pt
+   :ed-decompress-pt
+   :convert-bytes-to-int
+   :with-ed-curve
+   :ed-nth-pt
+   :ed-random-pair)
+  (:import-from :ecc-crypto-b571
+                :convert-int-to-nbytesv)
+  #+(or) ;; DBM: which symbol should we be calling here? -- MTE
+  (:shadow
+   :convert-bytes-to-int)
+  (:export))
+
+;; from cosi-construction
+(defpackage :cosi-simgen
+  (:use :common-lisp :cosi :crypto-mod-math)
+  (:import-from :edwards-ecc
+   :ed-add 
+   :ed-sub 
+   :ed-mul 
+   :ed-div 
+   :ed-affine
+   :ed-nth-pt
+   :*ed-r*
+   :*ed-q*
+   :ed-neutral-point
+   :ed-pt=
+   :with-ed-curve
+   :ed-compress-pt
+   :ed-decompress-pt
+   :ed-validate-point
+   :ed-hash
+   :ed-random-pair)
+  (:import-from :ecc-crypto-b571
+   :random-between
+   :convert-int-to-nbytesv
+   :convert-bytes-to-int)
+  (:import-from :actors
+   :=bind
+   :=values
+   :=defun
+   :=lambda
+   :=funcall
+   :=apply
+   :pmapcar
+   :spawn
+   :current-actor
+   :recv
+   :become
+   :do-nothing
+   :make-actor
+   :set-executive-pool
+   :with-borrowed-mailbox
+   :pr)
+  (:export
+   :generate-tree
+   :reconstruct-tree
+   :forwarding))
+
+;;; from random-partition
+#+(or)
+(defpackage :cosi-simgen
+  (:use :common-lisp :cosi :crypto-mod-math)
+  (:import-from :edwards-ecc
+   :ed-add 
+   :ed-sub 
+   :ed-mul 
+   :ed-div 
+   :ed-affine
+   :ed-nth-pt
+   :*ed-r*
+   :*ed-q*
+   :ed-neutral-point
+   :ed-pt=
+   :with-ed-curve
+   :ed-compress-pt
+   :ed-decompress-pt
+   :ed-validate-point
+   :ed-hash
+   :ed-random-pair)
+  (:import-from :ecc-crypto-b571
+   :convert-int-to-nbytesv
+   :convert-bytes-to-int)
+  (:import-from :actors
+   :=bind
+   :=values
+   :=defun
+   :=lambda
+   :=funcall
+   :=apply
+   :pmapcar
+   :spawn
+   :current-actor
+   :recv
+   :become
+   :do-nothing
+   :make-actor
+   :set-executive-pool
+   :with-borrowed-mailbox
+   :pr)
+  (:export
+   :generate-tree
+   :reconstruct-tree
+   :forwarding))
+

--- a/src/Cosi/random-partition.lisp
+++ b/src/Cosi/random-partition.lisp
@@ -27,50 +27,6 @@ THE SOFTWARE.
 |#
 
 
-(defpackage :cosi-simgen
-  (:use :common-lisp :cosi :crypto-mod-math)
-  (:import-from :edwards-ecc
-   :ed-add 
-   :ed-sub 
-   :ed-mul 
-   :ed-div 
-   :ed-affine
-   :ed-nth-pt
-   :*ed-r*
-   :*ed-q*
-   :ed-neutral-point
-   :ed-pt=
-   :with-ed-curve
-   :ed-compress-pt
-   :ed-decompress-pt
-   :ed-validate-point
-   :ed-hash
-   :ed-random-pair)
-  (:import-from :ecc-crypto-b571
-   :convert-int-to-nbytesv
-   :convert-bytes-to-int)
-  (:import-from :actors
-   :=bind
-   :=values
-   :=defun
-   :=lambda
-   :=funcall
-   :=apply
-   :pmapcar
-   :spawn
-   :current-actor
-   :recv
-   :become
-   :do-nothing
-   :make-actor
-   :set-executive-pool
-   :with-borrowed-mailbox
-   :pr)
-  (:export
-   :generate-tree
-   :reconstruct-tree
-   :forwarding))
-
 (in-package :cosi-simgen)
 
 (declaim (optimize (debug 3)))

--- a/src/Cosi/range-proofs.lisp
+++ b/src/Cosi/range-proofs.lisp
@@ -49,37 +49,6 @@ THE SOFTWARE.
 ;; Algebraic aggregation will save even more memory, shrinking the
 ;; cost dramatically with an O(Log2(N)) cost on N-proof aggregates.
 
-(defpackage :range-proofs
-  (:use :common-lisp :crypto-mod-math)
-  (:import-from :edwards-ecc
-   :ed-mul
-   :ed-add
-   :ed-sub
-   :ed-div
-   :ed-negate
-   :ed-affine
-   :*edcurve*
-   :*ed-r*
-   :*ed-q*
-   :*ed-gen*
-   :ed-curve-name
-   :random-between
-   :ed-pt=
-   :ed-compress-pt
-   :ed-decompress-pt
-   :with-ed-curve
-   :ed-nth-pt
-   :ed-random-pair
-   )
-  (:import-from :ecc-crypto-b571
-   :convert-int-to-nbytesv
-   :convert-bytes-to-int)
-  (:export
-   :make-range-proofs
-   :validate-range-proofs
-   :range-proof-block
-   ))
-
 (in-package :range-proofs)
 
 ;; ------------------------------

--- a/src/Cosi/range-proofs.lisp
+++ b/src/Cosi/range-proofs.lisp
@@ -295,7 +295,11 @@ THE SOFTWARE.
 ;; Construct a range-prover for use on multiple values
 
 (defun make-range-prover (&key (nbits *max-bit-length*))
+  #-ccl
   (check-type nbits (fixnum 1))
+  #+ccl
+  (check-type nbits fixnum)
+  
   ;; let's compute the basis vectors just once, and share them
   (let* ((hpt  *hpt*)
          (hs   *hs*)

--- a/src/Cosi/t/base.lisp
+++ b/src/Cosi/t/base.lisp
@@ -1,0 +1,9 @@
+(in-package :cl-user)
+
+(prove:plan 1)
+
+(prove:pass "A successful test of passing a test.")
+
+(prove:finalize)
+
+   

--- a/src/Cosi/t/ranges-timing.lisp
+++ b/src/Cosi/t/ranges-timing.lisp
@@ -1,8 +1,8 @@
 (in-package cl-user)
 
 (prove:plan 1)
-(let ((n 123) ;; ?? What is a reasonable range of values
-      (nbits 4))
+(let ((n 128) ;; ?? What is a reasonable range of values
+      (nbits 64))
   (let* ((prover (range-proofs:make-range-prover :nbits nbits))
          (proof (funcall prover n)))
     (prove:ok

--- a/src/Cosi/t/ranges-timing.lisp
+++ b/src/Cosi/t/ranges-timing.lisp
@@ -1,0 +1,30 @@
+(in-package :cl-user)
+
+(prove:plan 1)
+(let ((n 123) ;; ?? What is a reasonable range of values
+      (nbits 4))
+  (let* ((prover (make-range-prover :nbits nbits))
+         (proof (funcall prover n)))
+    (prove:ok
+     (range-proofs:validate-range-proof proof)
+     "Testing VALIDATE-RANGE-PROOF…")))
+
+(prove:plan 1)
+(let ((niter 1000))
+  (let ((result (multiple-value-list 
+                 (time (loop repeat niter do
+                            (tst (random-between 0 #.(1- (ash 1 64))) :nbits 64))))))
+    
+
+(defun proof-timing-test (&optional (niter 1000))
+  (time (loop repeat niter do
+              (let ((prover (make-range-prover :nbits 64)))
+                (funcall prover (random-between 0 #.(1- (ash 1 64))))))))
+
+(defun verifier-timing-test (&optional (niter 1000))
+  (let* ((prover (make-range-prover :nbits 64))
+         (proof  (funcall prover (random-between 0 #.(1- (ash 1 64))))))
+    (time (loop repeat niter do
+                (validate-range-proof proof)))))
+
+(prove:finalize)

--- a/src/Cosi/t/ranges-timing.lisp
+++ b/src/Cosi/t/ranges-timing.lisp
@@ -1,4 +1,4 @@
-(in-package :cl-user)
+(in-package cl-user)
 
 (prove:plan 1)
 (let ((n 123) ;; ?? What is a reasonable range of values
@@ -9,13 +9,13 @@
      (range-proofs:validate-range-proof proof)
      "Testing VALIDATE-RANGE-PROOF…")))
 
+#|     TODO: finish transcribing…
 (prove:plan 1)
 (let ((niter 1000))
   (let ((result (multiple-value-list 
                  (time (loop repeat niter do
                             (tst (random-between 0 #.(1- (ash 1 64))) :nbits 64))))))
     
-
 (defun proof-timing-test (&optional (niter 1000))
   (time (loop repeat niter do
               (let ((prover (make-range-prover :nbits 64)))
@@ -26,5 +26,6 @@
          (proof  (funcall prover (random-between 0 #.(1- (ash 1 64))))))
     (time (loop repeat niter do
                 (validate-range-proof proof)))))
+|#
 
 (prove:finalize)

--- a/src/Cosi/t/ranges-timing.lisp
+++ b/src/Cosi/t/ranges-timing.lisp
@@ -3,7 +3,7 @@
 (prove:plan 1)
 (let ((n 123) ;; ?? What is a reasonable range of values
       (nbits 4))
-  (let* ((prover (make-range-prover :nbits nbits))
+  (let* ((prover (range-proofs:make-range-prover :nbits nbits))
          (proof (funcall prover n)))
     (prove:ok
      (range-proofs:validate-range-proof proof)

--- a/src/Crypto/edwards.lisp
+++ b/src/Crypto/edwards.lisp
@@ -548,7 +548,7 @@ THE SOFTWARE.
   (sha3-buffers (ed-compress-pt pt :lev t)))
 
 (defun ed-random-pair ()
-  (let* ((r  (random-between 1 *ed-r*))
+  (let* ((r  (* *ed-h* (random-between 1 *ed-r*)))
          (pt (ed-nth-pt r)))
     (values r pt)))
 

--- a/src/emotiq-tests.asd
+++ b/src/emotiq-tests.asd
@@ -1,10 +1,19 @@
-;;;; emotiq-tests.asd
+;;; -*- Mode: LISP; Syntax: COMMON-LISP -*-
 
 (defsystem "emotiq-tests"
+  :version "0.0.1"
   :description "Emotiq Tests"
   :author "Copyright (c) 2018 Emotiq AG"
   :license "MIT (see LICENSE.txt)"
-  :depends-on (#:emotiq #:lisp-unit)
+  :depends-on (emotiq lisp-unit)
+  :perform (test-op (o s)
+             (symbol-call :lisp-unit :run-tests
+                          :all (slot-value s 'asdf/component:name))) ;; REALLY?
+                                                                     ;; TODO:
+                                                                     ;; implement
+                                                                     ;; a
+                                                                     ;; reasonable
+                                                                     ;; stringify
   :pathname #P"tests/"
   :serial t
   :components ((:file "package")

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -1,4 +1,4 @@
-;;;; emotiq.asd
+;;; -*- Mode: LISP; Syntax: COMMON-LISP -*-
 
 (defsystem "emotiq"
   :description "Emotiq"
@@ -6,53 +6,8 @@
   :license "MIT (see LICENSE.txt)"
   :depends-on (#:ironclad #:bordeaux-threads)
   :serial t
-  :perform (test-op (o s)
-                    (uiop:symbol-call :lisp-unit :run-tests
-                                      :all '#:emotiq-tests))
+  :in-order-to ((test-op (test-op "emotiq-tests")))
   :components ((:file "package")
                (:file "utilities")
                (:file "external"))
   :in-order-to ((test-op (test-op "emotiq-tests"))))
-
-
-#| Abbreviated instructions for a test build in the Lisp REPL:
-
-0. [Something about assumption that Quicklisp has been set up....!] 
-
-1. Tell ASDF where to find system: (Substitute as appropriate for "/path/to/".)
-
-EITHER do step 1.1 OR step 1.2
-
-1.1 Dynamically configure
-
-  (pushnew (pathname "/path/to/emotiq/src/") asdf:*central-registry* :test 'equal)
-
-1.2 Configure to have the lisp dynamically scan the filesystem at boot
-for ASDF source registry DSL artifacts.  
-
-Assuming the source to <https://github.com/Emotiq/emotiq> has been
-cloned to <file:///~/work/github.com-Emotiq/emotiq/>,
-
-  (uiop:run-program "mkdir -p ~/.config/common-lisp/source-registry.conf.d/ && cp ~/work/github.com-Emotiq/emotiq/etc/emotiq.conf ~/.config/common-lisp/source-registry.conf.d/")
-
-2. Ensure Quicklisp dependencies have been satified
-
-  (ql:quickload :emotiq-tests)
-
-3. Evaluate form to test, which also loads, the system:
-
-  (asdf:test-system :emotiq)
-
-4. At end you should see a result like
-  
-    Unit Test Summary
-     | 12 assertions total
-     | 12 passed
-     | 0 failed
-     | 0 execution errors
-     | 0 missing tests
-
-The counts of assertions/passed should go up over time, and should
-stay equal, with other counts staying zero.
-
-|#

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -1,13 +1,28 @@
 ;;; -*- Mode: LISP; Syntax: COMMON-LISP -*-
 
 (defsystem "emotiq"
+  :version "0.0.1"
   :description "Emotiq"
   :author "Copyright (c) 2018 Emotiq AG"
   :license "MIT (see LICENSE.txt)"
-  :depends-on (#:ironclad #:bordeaux-threads)
+  :depends-on (ironclad
+               bordeaux-threads)
   :serial t
-  :in-order-to ((test-op (test-op "emotiq-tests")))
+  :in-order-to ((test-op (test-op "emotiq/t")))
   :components ((:file "package")
                (:file "utilities")
-               (:file "external"))
-  :in-order-to ((test-op (test-op "emotiq-tests"))))
+               (:file "external")))
+
+(defsystem "emotiq/t"
+  :version "0.0.1"
+  :description "Emotiq"
+  :author "Copyright (c) 2018 Emotiq AG"
+  :license "MIT (see LICENSE.txt)"
+  :defsystem-depends-on (prove-asdf)
+  :depends-on (prove
+               emotiq)
+  :perform (test-op (o s)
+              (symbol-call :prove :run s))
+  :components ((:module tests :pathname "t/"
+                        :components ((:test-file "base")
+                                     (:test-file "tests")))))

--- a/src/t/base.lisp
+++ b/src/t/base.lisp
@@ -1,0 +1,9 @@
+(in-package :cl-user)
+
+(prove:plan 1)
+
+(prove:pass "A successful test of compiling and runing a test.")
+
+(prove:finalize)
+
+   

--- a/src/t/base.lisp
+++ b/src/t/base.lisp
@@ -2,7 +2,7 @@
 
 (prove:plan 1)
 
-(prove:pass "A successful test of compiling and runing a test.")
+(prove:pass "A successful test of compiling dependencies and passing a test.")
 
 (prove:finalize)
 

--- a/src/t/tests.lisp
+++ b/src/t/tests.lisp
@@ -1,0 +1,71 @@
+(in-package cl-user)
+
+(let ((test-hex-string "a0b1c2d3e4f56789"))
+  (prove:plan 3)
+  (prove:diag "octet-vector-to-hex-string")
+  (let ((octet-vector (emotiq:hex-string-to-octet-vector test-hex-string)))
+    (prove:is (emotiq:octet-vector-p octet-vector)
+              t
+              "octet-vector-p…")
+    ;; length of octet vector should be 1/2 that of hex string
+    (prove:is (length octet-vector)
+              (floor (length test-hex-string) 2)
+              "length octect-vector…")
+    (let ((back-hex-string (emotiq:octet-vector-to-hex-string octet-vector)))
+      (prove:is back-hex-string
+                test-hex-string
+                "bach-hex in octect-vector-to-hex-string…"))))
+
+(prove:plan 1)
+(prove:is (ovref (hex-string-to-octet-vector "3d") 0) #x3d
+          "hex-string-to-octet-vector…")
+
+(let ((string-rosetta-code "Rosetta code"))
+
+  (prove:plan 2)
+  (let ((digest (emotiq:sha-256-string string-rosetta-code)))
+    (prove:is
+     digest
+     "764faf5c61ac315f1497f9dfa542713965b785e5cc2f707d6468d7d1124cdfcf"
+     "sha256-string…")
+    (prove:is (length digest)
+              64
+              "digest length…"))
+
+  (prove:plan 2)
+  (let ((digest (emotiq:sha-256-vector string-rosetta-code)))
+    (prove:is digest
+              #(118 79 175 92 97 172 49 95 20 151 249 223 165 66 113
+                57 101 183 133 229 204 47 112 125 100 104 215 209 18
+                76 223 207)
+              "Vector of digest…")
+    (prove:is (length digest)
+              32
+              "Length of digest…"))
+  (prove:plan 2)
+  (let ((digest (emotiq:sha3-512-string string-rosetta-code)))
+    (prove:is 
+     digest   
+     "a05395817c9c06a4dfbf88553041463b8a4ace62f438d4f74a61356a66a232b69512544b303be599aa875af1803f3afc2ebe57f1b7a5226717baefc2470d4574"
+     "sha3-512-string…")
+    (prove:is (length digest)
+              128
+              "sha3-512-string digest length…"))
+
+  (prove:plan 2)
+  (let ((digest (emotiq:sha3-512-vector string-rosetta-code)))
+    (prove:is digest
+              #(160 83 149 129 124 156 6 164 223 191 136 85 48 65 70
+               59 138 74 206 98 244 56 212 247 74 97 53 106 102 162 50
+               182 149 18 84 75 48 59 229 153 170 135 90 241 128 63 58
+               252 46 190 87 241 183 165 34 103 23 186 239 194 71 13
+                69 116)
+              "sha3-512 vector comparison…")
+    (prove:is (length digest)
+              64
+              "sha3-512 vector digest length…")))
+
+(prove:finalize)
+
+
+

--- a/src/t/tests.lisp
+++ b/src/t/tests.lisp
@@ -14,10 +14,11 @@
     (let ((back-hex-string (emotiq:octet-vector-to-hex-string octet-vector)))
       (prove:is back-hex-string
                 test-hex-string
-                "bach-hex in octect-vector-to-hex-string…"))))
+                "back-hex in octect-vector-to-hex-string…"))))
 
 (prove:plan 1)
-(prove:is (ovref (hex-string-to-octet-vector "3d") 0) #x3d
+(prove:is (emotiq ovref (emotiq:hex-string-to-octet-vector "3d") 0)
+          #x3d
           "hex-string-to-octet-vector…")
 
 (let ((string-rosetta-code "Rosetta code"))
@@ -38,6 +39,7 @@
               #(118 79 175 92 97 172 49 95 20 151 249 223 165 66 113
                 57 101 183 133 229 204 47 112 125 100 104 215 209 18
                 76 223 207)
+              :test #'equalp
               "Vector of digest…")
     (prove:is (length digest)
               32
@@ -60,6 +62,7 @@
                182 149 18 84 75 48 59 229 153 170 135 90 241 128 63 58
                252 46 190 87 241 183 165 34 103 23 186 239 194 71 13
                 69 116)
+              :test #'equalp
               "sha3-512 vector comparison…")
     (prove:is (length digest)
               64

--- a/src/t/tests.lisp
+++ b/src/t/tests.lisp
@@ -2,7 +2,8 @@
 
 (let ((test-hex-string "a0b1c2d3e4f56789"))
   (prove:plan 3)
-  (prove:diag "octet-vector-to-hex-string")
+  (prove:diag
+   (format nil "emotiq:hex-string-to-octet-vector on ~s…" test-hex-string)) 
   (let ((octet-vector (emotiq:hex-string-to-octet-vector test-hex-string)))
     (prove:is (emotiq:octet-vector-p octet-vector)
               t
@@ -14,15 +15,16 @@
     (let ((back-hex-string (emotiq:octet-vector-to-hex-string octet-vector)))
       (prove:is back-hex-string
                 test-hex-string
-                "back-hex in octect-vector-to-hex-string…"))))
+                "back-hex in emotiq:octet-vector-to-hex-string…"))))
 
 (prove:plan 1)
-(prove:is (emotiq ovref (emotiq:hex-string-to-octet-vector "3d") 0)
+(prove:is (emotiq:ovref (emotiq:hex-string-to-octet-vector "3d") 0)
           #x3d
-          "hex-string-to-octet-vector…")
+          "emotiq:ovvref on emotiq:hex-string-to-octet-vector…")
 
 (let ((string-rosetta-code "Rosetta code"))
-
+  (prove:diag
+   (format nil "Testing crypto on ~s" string-rosetta-code))
   (prove:plan 2)
   (let ((digest (emotiq:sha-256-string string-rosetta-code)))
     (prove:is

--- a/src/useful-macros/ppcre-reader.lisp
+++ b/src/useful-macros/ppcre-reader.lisp
@@ -43,7 +43,7 @@ THE SOFTWARE.
 (defmacro! match-mode-ppcre-lambda-form (o!args)
   ``(lambda (,',g!str)
       (cl-ppcre:scan
-       ,(car ',g!args)
+       ,(car ,g!args)
        ,',g!str)))
 
 #+cl-ppcre

--- a/src/useful-macros/ppcre-reader.lisp
+++ b/src/useful-macros/ppcre-reader.lisp
@@ -43,7 +43,7 @@ THE SOFTWARE.
 (defmacro! match-mode-ppcre-lambda-form (o!args)
   ``(lambda (,',g!str)
       (cl-ppcre:scan
-       ,(car ,g!args)
+       ,(car ',g!args)
        ,',g!str)))
 
 #+cl-ppcre


### PR DESCRIPTION
This branch combines the adding of the Travis CI artifact [to test across six open ANSI implementations](https://travis-ci.org/emotiq/emotiq/builds/), restores @dbmcclain 's ppcre macrology to the correct form (remains broken under `sbcl`), and uses [Fukamachi's PROVE](https://github.com/fukamachi/prove/)  to easily hook into invoking tests for a given PROVE-ASDF system.