### PR TITLE
Move reader macro example from #|...|# to ;... for SBCL

### DIFF
--- a/src/useful-macros/ppcre-reader.lisp
+++ b/src/useful-macros/ppcre-reader.lisp
@@ -85,10 +85,13 @@ THE SOFTWARE.
 #+cl-ppcre
 (set-dispatch-macro-character #\# #\~ '|reader-for-#~|)
 
-#| ;; example
-;; pattern matching
-(#~m/^[+-]?[0-9][0-9_,]*(\.[0-9_,]*([eEdD][+-]?[0-9]+)?)?/ s)
-;; pattern substitution
-(#~s/[0-9]/N/ s)
-|#
-
+;; example
+;;
+;;   pattern matching
+;;
+;;     (#~m/^[+-]?[0-9][0-9_,]*(\.[0-9_,]*([eEdD][+-]?[0-9]+)?)?/ s)
+;;
+;;
+;;   pattern substitution
+;;
+;;     (#~s/[0-9]/N/ s)


### PR DESCRIPTION

SBCL could not handle this evidently. It was giving very strange error messages. Meanwhile this code is extremely hairy.

Meanwhile, the semicolon comment style seems just fine, and I actually prefer it, personally.  I added a bit of vertical whitespace and indentation while I was at it, making things a bit clearer.

When you think about it, this had been such a tour-de-force that it almost had to break on at least one CL implementation, and so SBCL is one case: (1) use of set-dispatch-macro-character is somewhat rare these days; (2) usage of macro definition instances within #|...|# is even rarer; (3) the occurance within the same file as the definition is rarer still.

Personally, I don't care much for #|...|# comments and rarely use them. And reader macros I use even less. I have not reviewed actually this or other of the many reader macros that David's "legacy" code brought to our project. I think we should only do that now IF we are about to be making extensive use of any of them. Otherwise, I think we can and should defer such a review.

I think this does represent a bug in SBCL, however. Can someone else take on isolating a more minimal reproducible case and reporting it to SBCL now?

Tested by hand in REPL. Log:
```
    CL-USER> '(#~m/^[+-]?[0-9][0-9_,]*(\.[0-9_,]*([eEdD][+-]?[0-9]+)?)?/ s)
    ((LAMBDA (#:STR8281) (CL-PPCRE:SCAN "^[+-]?[0-9][0-9_,]*(\\.[0-9_,]*([eEdD][+-]?[0-9]+)?)?" #:STR8281)) S)
    CL-USER> '(#~s/[0-9]/N/ s)
    ((LAMBDA (#:STR8282) (CL-PPCRE:REGEX-REPLACE-ALL "[0-9]" #:STR8282 "N")) S)
```
Does that look right? (@dbmcclain?)