### PR TITLE
Fix reader macro issues on SBCL

### DIFF
--- a/src/useful-macros/basic-useful.lisp
+++ b/src/useful-macros/basic-useful.lisp
@@ -105,14 +105,25 @@ THE SOFTWARE.
 
 ;; ----------------------------------------------
 
+#+sbcl
+(if (string-lessp (lisp-implementation-version) "1.2.2")
+    (pushnew :safe-sbcl *features*)
+    (setq *features* (remove :safe-sbcl *features*)))
+
 (defun flatten (x)
   ;; this is really a deep flatten
   (labels ((rec (x acc)
              (cond ((null x) acc)
+                   #+(and sbcl (not safe-sbcl))
+                   ((typep x 'sb-impl::comma) (rec (sb-impl::comma-expr x) acc))
                    ((atom x) (cons x acc))
                    (t  (rec (car x) (rec (cdr x) acc)))
                    )))
     (rec x nil)))
+
+;; #+sbcl code above adapted from
+;; #https://github.com/thephoeron/let-over-lambda/blob/a202167629cb421cbc2139cfce1db22a84278f9f/let-over-lambda.lisp
+
 
 (defmacro perform (name bindings &body body)
   (let ((args (mapcar 'first bindings))

--- a/src/useful-macros/ppcre-reader.lisp
+++ b/src/useful-macros/ppcre-reader.lisp
@@ -85,10 +85,23 @@ THE SOFTWARE.
 #+cl-ppcre
 (set-dispatch-macro-character #\# #\~ '|reader-for-#~|)
 
-#| ;; example
-;; pattern matching
-(#~m/^[+-]?[0-9][0-9_,]*(\.[0-9_,]*([eEdD][+-]?[0-9]+)?)?/ s)
-;; pattern substitution
-(#~s/[0-9]/N/ s)
-|#
-
+;; Examples you can input to READ:
+;;
+;;   Pattern Matching:
+;;
+;;     (#~m/^[+-]?[0-9][0-9_,]*(\.[0-9_,]*([eEdD][+-]?[0-9]+)?)?/ s)
+;;
+;;     =>
+;;
+;;       ((LAMBDA (#:STR8281) (CL-PPCRE:SCAN "^[+-]?[0-9][0-9_,]*(\\.[0-9_,]*([eEdD][+-]?[0-9]+)?)?" #:STR8281)) S)
+;;
+;;
+;;   Pattern Substitution:
+;;
+;;     (#~s/[0-9]/N/ s)
+;;
+;;     =>
+;;
+;;      ((LAMBDA (#:STR8282) (CL-PPCRE:REGEX-REPLACE-ALL "[0-9]" #:STR8282 "N")) S)
+;;
+;; (Note: the uninterned symbols in the examples are not exact, just representative gensyms.)


### PR DESCRIPTION
The #+SBCL reader-conditioinalized code should help with SBCL 2.2
issues. To the extent that it helps, we thank Christophe's informative
blog post here
http://christophe.rhodes.io/notes/blog/posts/2014/naive_vs_proper_code-walking/
Note that he gave numerous caveats and warnings, which we are for now
disregarding, so we are responsible if this of limited value, as he
explains in his blog at length.

While diving in I rubbed my eyes a lot and figured out what the heck the example
was meant to be.  So I rewrote it for clarity.  Hopefully, it's clearer.