### PR TITLE
define & use defconstant+ for non-eql-comparable values (SBCL needs)

### DIFF
--- a/src/useful-macros/basic-useful.lisp
+++ b/src/useful-macros/basic-useful.lisp
@@ -138,3 +138,20 @@ THE SOFTWARE.
 
 ;; -------------------------------------------
 
+
+
+;;; DEFCONSTANT+: Defconstant PLUS a bit of common sense.
+
+(defmacro defconstant+ (name value &optional doc)
+  "Like DEFCONSTANT but does not allow you to (easily) change the
+  value once you've evaluated the form."
+  ;; In return, if you do something like 
+  ;;
+  ;;   (progn (defconstant foo "bar") (defconstant foo "bar"))
+  ;;
+  ;; SBCL (justified by Common Lisp) will not say things like
+  ;;
+  ;;   The constant FOO is being redefined (from "bar" to "bar")
+  `(defconstant ,name 
+     (if (boundp ',name) (symbol-value ',name) ,value)
+     ,@(if doc (list doc))))

--- a/src/useful-macros/cache.lisp
+++ b/src/useful-macros/cache.lisp
@@ -30,8 +30,8 @@ THE SOFTWARE.
 
 ;; -----------------------------------------------------------
 
-(defconstant +empty+      #())
-(defconstant +empty-cell+ (list +empty+))
+(um:defconstant+ +empty+      #())
+(um:defconstant+ +empty-cell+ (list +empty+))
 
 (defun cache (fn &key (test #'equal))
   ;; provide a simple 2-way associative cache on function fn

--- a/src/useful-macros/packages.lisp
+++ b/src/useful-macros/packages.lisp
@@ -309,6 +309,8 @@ THE SOFTWARE.
    #:dcase)
   (:export
 
+   :defconstant+
+
    #:lc
    #:def-typed-fn
    

--- a/src/useful-macros/uuid.lisp
+++ b/src/useful-macros/uuid.lisp
@@ -127,13 +127,13 @@ INTERNAL-TIME-UINITS-PER-SECOND which gives the ticks per count for the current 
 		   :node (parse-integer uuid-string :start 24 :end 36 :radix 16))))
 
 ;; Those should be constants but I couldn't find a way to define a CLOS object to be constant
-(defconstant +namespace-dns+ (make-uuid-from-string "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+(um:defconstant+ +namespace-dns+ (make-uuid-from-string "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
   "The DNS Namespace. Can be used for the generation of uuids version 3 and 5")
-(defconstant +namespace-url+ (make-uuid-from-string "6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+(um:defconstant+ +namespace-url+ (make-uuid-from-string "6ba7b811-9dad-11d1-80b4-00c04fd430c8")
   "The URL Namespace. Can be used for the generation of uuids version 3 and 5")
-(defconstant +namespace-oid+ (make-uuid-from-string "6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+(um:defconstant+ +namespace-oid+ (make-uuid-from-string "6ba7b812-9dad-11d1-80b4-00c04fd430c8")
   "The OID Namespace. Can be used for the generation of uuids version 3 and 5")
-(defconstant +namespace-x500+ (make-uuid-from-string "6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+(um:defconstant+ +namespace-x500+ (make-uuid-from-string "6ba7b814-9dad-11d1-80b4-00c04fd430c8")
   "The x500+ Namespace. Can be used for the generation of uuids version 3 and 5")
 
 #+(AND :MACOSX :LISPWORKS)


### PR DESCRIPTION
SBCL stops the show if you defconstant with a value that can't be compared using EQL, that is, on the second and subsequent evaluations it throws an error about it. So I defined defconstant+. If this is a subsequent evaluation, it just sets the value of the constant to the identical (old) value, never comparing at all.