### PR TITLE
Fix 1st arg to MAP, must be sequence type, not function. SBCL NOT amused

### DIFF
--- a/src/useful-macros/useful-macros.lisp
+++ b/src/useful-macros/useful-macros.lisp
@@ -1841,7 +1841,7 @@ This is C++ style enumerations."
   (values (read-from-string (apply #'mkstr args))))
 
 (defun explode (sym)
-  (map #'list (compose #'intern-symbol #'string) (symbol-name sym)))
+  (map 'list (compose #'intern-symbol #'string) (symbol-name sym)))
 
 ;; -------------------------------------------------------
 ;;


### PR DESCRIPTION
There was an unused defun with a subform of the form (map #'list ...), whereas it should have been of the form (map 'list ...). The second arg to map must be a sequence subtype. SBCL's compiler is not at all cool with this, and the interaction with ASDF is terrible: all you see is: COMPILE-FILE-ERROR while.... and nothing much else of substance. So this was NOT fun to track down.