### PR TITLE
SBCL - last tango

### DIFF
--- a/src/Cosi/base58.lisp
+++ b/src/Cosi/base58.lisp
@@ -35,7 +35,7 @@ THE SOFTWARE.
 
 ;; from https://bitcointalk.org/index.php?topic=1026.0
 
-(defconstant +alphabet+
+(um:defconstant+ +alphabet+
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
 (defconstant +len+
   (length +alphabet+)) ;; should be 58

--- a/src/Cosi/cosi-construction.lisp
+++ b/src/Cosi/cosi-construction.lisp
@@ -57,7 +57,9 @@ THE SOFTWARE.
 (defparameter *default-timeout-period*   ;; good for 1600 nodes on single machine
   #+:LISPWORKS   10
   #+:ALLEGRO     70
-  #+:CLOZURE     70)
+  #+:CLOZURE     70
+  #-(or :LISPWORKS :ALLEGRO :CLOZURE)
+  70)
 
 ;; ----------------------------------------------------------------------
 ;; Network Tree Nodes
@@ -260,12 +262,16 @@ THE SOFTWARE.
 (defun dotted-string-to-integer (string)
   #+:LISPWORKS (comm:string-ip-address string)
   #+:OPENMCL   (ccl::dotted-to-ipaddr string)
-  #+:ALLEGRO   (allegro-dotted-to-integer string))
+  #+:ALLEGRO   (allegro-dotted-to-integer string)
+  #-(or :LISPWORKS :ALLEGRO :CLOZURE)
+  (usocket:host-byte-order string))
 
 (defun integer-to-dotted-string (val)
   #+:LISPWORKS (comm:ip-address-string val)
   #+:OPENMCL (CCL::ipaddr-to-dotted val)
-  #+:ALLEGRO (allegro-integer-to-dotted val))
+  #+:ALLEGRO (allegro-integer-to-dotted val)
+  #-(or :LISPWORKS :ALLEGRO :CLOZURE)
+  (usocket:host-byte-order val))
 
 (defun gen-uuid-int ()
   (uuid:uuid-to-integer (uuid:make-v1-uuid)))

--- a/src/Cosi/cosi-construction.lisp
+++ b/src/Cosi/cosi-construction.lisp
@@ -271,7 +271,7 @@ THE SOFTWARE.
   #+:OPENMCL (CCL::ipaddr-to-dotted val)
   #+:ALLEGRO (allegro-integer-to-dotted val)
   #-(or :LISPWORKS :ALLEGRO :CLOZURE)
-  (usocket:host-byte-order val))
+  (usocket:hbo-to-dotted-quad val))
 
 (defun gen-uuid-int ()
   (uuid:uuid-to-integer (uuid:make-v1-uuid)))

--- a/src/Cosi/cosi-keying.lisp
+++ b/src/Cosi/cosi-keying.lisp
@@ -114,7 +114,7 @@ THE SOFTWARE.
 ;; math operations like for range proofs and such. And range proofs
 ;; also present special problems with respect to Elligator encodings.
 
-(defconstant +keying-msg+  #(:keying-{61031482-17DB-11E8-8786-985AEBDA9C2A}))
+(um:defconstant+ +keying-msg+  #(:keying-{61031482-17DB-11E8-8786-985AEBDA9C2A}))
 
 (defun make-deterministic-keypair (seed &optional (index 0))
   ;; WARNING!! This version is for testing only. Two different users


### PR DESCRIPTION
Some last non-LispWorks changes fixing some net utils, fix 2 defconstants.
The non-LispWorks changes are minimal changes, not wanting to take precious time to review.
But these were done and ready at the tail end of when we were still trying to get SBCL to work,
so may as well get them in before putting SBCL in the freezer for a few months.
FWIW on SBCL system "cosi" actually builds to completion in this branch, assuming you can convince ASDF to NOT signal an error due to the existence of non-style warnings (which I know how to do, but it's involved; see research branch).