### PR TITLE
Instruct the CI to only run LispWorks as agreed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ env:
 
   matrix:
     - LISP=lispworks-bin
-    - LISP=ccl-bin
-    - LISP=sbcl-bin
 # Uncomment to enable the build farm resource to be spent on
 # implementations that might actually produce useful results.
+#    - LISP=ccl-bin
+#    - LISP=sbcl-bin
 #    - LISP=abcl-bin
 # Non-binary distributions need to be built from source, which
 # currently times out for the Travis CI builds we are currently paying


### PR DESCRIPTION
Developers may renable test coverage for tests for a given
implementation by uncommenting the necessary lines to this script in
their development branch.