### PR TITLE
Fix ASDF dependencies

### DIFF
--- a/src/emotiq-test.asd
+++ b/src/emotiq-test.asd
@@ -1,11 +1,12 @@
 ;;; -*- Mode: LISP; Syntax: COMMON-LISP -*-
 
 (defsystem "emotiq-test"
-  :version "0.0.1"
+  :version "0.0.2"
   :description "Emotiq Tests"
   :author "Copyright (c) 2018 Emotiq AG"
   :license "MIT (see LICENSE.txt)"
-  :depends-on (emotiq lisp-unit)
+  :depends-on (lisp-unit
+               emotiq/utilities)
   :perform (test-op (o s)
              (symbol-call :lisp-unit :run-tests
                           :all :emotiq-test))

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -1,16 +1,35 @@
 ;;; -*- Mode: LISP; Syntax: COMMON-LISP -*-
 
 (defsystem "emotiq"
-  :version "0.0.2"
+  :version "0.0.3"
   :description "Emotiq"
   :author "Copyright (c) 2018 Emotiq AG"
   :license "MIT (see LICENSE.txt)"
-  :depends-on (ironclad
-               bordeaux-threads)
-  :serial t
+  :depends-on nil ;; DO NOT add dependencies here; create a secondary
+                  ;; system to encapsulate them which :DEPENDS-ON this
+                  ;; one.
   :in-order-to ((test-op (test-op "emotiq-test")))
-  :components ((:file "package")
-               (:file "utilities")
-               (:file "external")
-               (:file "blockchain")))
+  :components ((:module package
+                :pathname "./"
+                :components ((:file "package")))))
+
+(defsystem "emotiq/utilities"  
+  :depends-on (emotiq
+               ironclad
+               bordeaux-threads)
+  :components ((:module source
+                :pathname "./"
+                :serial t
+                :components ((:file "utilities")
+                             (:file "external")))))
+
+(defsystem "emotiq/blockchain"
+  :depends-on (emotiq/utilities)
+  :components ((:module source
+                :pathname "./"
+                :serial t
+                :components ((:file "blockchain")))))
+                                       
+
+
 


### PR DESCRIPTION
We include only the package definitions in the EMOTIQ system without
any direct dependencies.  Otherwise, one will quickly end up with
recursive definitions that don't compile or, worse, systems whose
behavior is dependent on unreproducible ASDF load ops if all systems
merely :DEPEND-ON.  This problem was evidenced in the delivery code
Paul was working on, so this is the minimal pre-emptive modification
to get into `dev` to disturb developers' productive lives as little as
possible.