### PR TITLE
Ci nuke fasls between tests --  Remove the cached fasl artifacts between test-system invocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ script:
                     (:cosi-bls :cosi-bls-test)
                     (:crypto-pairings :crypto-pairings/t))
               :doing 
+              (progn
+                 (uiop:run-program "rm -rf ~/.cache/")
                  (ql:quickload dependencies)
               :unless 
                  (asdf:test-system system)

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ script:
                     (:crypto-pairings :crypto-pairings/t))
               :doing 
               (progn
-                 (uiop:run-program "rm -rf ~/.cache/")
-                 (ql:quickload dependencies)
+                 (uiop:run-program \"rm -rf ~/.cache/\")
+                 (ql:quickload dependencies))
               :unless 
                  (asdf:test-system system)
               :return 


### PR DESCRIPTION
Isolates inter ASDF system dependencies to reveal incomplete
dependency declarations.

Developers are advised to add their ASDF definitions to the LOOP form
explicitly if they wish such coverage.