### PR TITLE
Fix ASDF definitions of crypto-pairings/t

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ script:
               :for 
                   (system dependencies) 
               :in 
-                  '((:core-crypto :core-crypto)) ; no test system, so system itself
+                  '((:core-crypto :core-crypto)) 
               :doing 
                  (ql:quickload dependencies)
               :unless 

--- a/src/Crypto/crypto-pairings.asd
+++ b/src/Crypto/crypto-pairings.asd
@@ -31,6 +31,7 @@ THE SOFTWARE.
   :components  ((:file "pbc-cffi")
                 (:file "proofs"))
   :depends-on   ("core-crypto"
+                 "emotiq"
                  "cffi"
                  "crypto-pairings/libraries"))
 
@@ -53,13 +54,14 @@ THE SOFTWARE.
        (format *standard-output* "~tWhew!  Finished.~&")))))
 
 (defsystem "crypto-pairings/t"
-  :depends-on (crypto-pairings)
+  :depends-on (crypto-pairings
+               lisp-unit)
   :perform (test-op (o s)
-                    (symbol-call :lisp-unit :run-tests
-                                 :all :pbc-test))
+             (symbol-call :lisp-unit :run-tests
+                          :all :pbc-test))
   :components ((:module package
-                        :pathname "tests/"
-                        :components ((:file "package")))
+                :pathname "tests/"
+                :components ((:file "package")))
                (:module tests
                 :depends-on (package)
                 :pathname "tests/"

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -24,8 +24,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 |#
 
-(asdf:load-system :cffi)
-
 (defpackage :pbc-interface
   (:use :common-lisp
         :core-crypto


### PR DESCRIPTION
Do NOT add invoke ASDF:LOAD-SYSTEM machinery in file compilation
units.  Instead, encapsulate such relationships in the ASDF
definitions themselves.