### PR TITLE
add shadows to use of BLOCK in package cosi/proofs (shadows cl:block)

### DIFF
--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -106,6 +106,7 @@
    :vec-repr
    :edec
    :pbc)
+  (:shadow :block)
   (:import-from :ecc-crypto-b571
    :random-between)
   (:export
@@ -147,6 +148,7 @@
    :vec-repr
    :hash
    :cosi/proofs)
+  (:shadow :block)
   (:import-from :edwards-ecc
    :ed-add 
    :ed-sub 


### PR DESCRIPTION
Paul pointed out that there's a package problem on David's branch dbm-0418b. This is not a problem in dev. There are two defpackage's needing :shadow forms. I fixed them in this little commit.  Here's a little PR to fix the branch if you'd like @dbmcclain  and @easye . (Thanks to @guitarvydas for working through this with me.)