### PR TITLE
Add public-key and bitmap to block hash for proper multi-signature support

### DIFF
--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -118,6 +118,8 @@
     prev-block-hash
     merkle-root-hash
     block-timestamp
+    public-keys-of-witnesses
+    witness-bitmap
     block-signature)
   "These slots are serialized and then hashed. The hash is stored as
    the prev-block-hash on a newer block on a blockchain.")


### PR DESCRIPTION
I think this is what David wanted. It's a bit hard for me to really test. You'd have to have a block with the public keys and bitmap filled in, as well as the signature.  But once that would be done, and assuming the loenc encoder all functions as advertised, this should all work straightforwardly.  Note that if any of the ```*names-of-block-slots-to-serialize*``` slots are not filled in when you call hash-block, you get an unbound-slot error, which it seems right for you to get now.