### PR TITLE
minor change from (machine-instance) to localhost

### DIFF
--- a/src/Cosi-BLS/cosi-config.lisp
+++ b/src/Cosi-BLS/cosi-config.lisp
@@ -6,7 +6,7 @@
 (defun cosi-init (leader-node-ip)
   "Steps necessary to initialize specials in the cosi-bls system to
    create a machine local simulation network."
-  (let ((machine-name (machine-instance)))
+  (let ((machine-name "localhost"))
     (setf *local-nodes*  `((,machine-name . ,leader-node-ip))
           *real-nodes*   (list leader-node-ip)
           *leader-node*  leader-node-ip)))


### PR DESCRIPTION
This fixes the "localhost" vs. "(machine-instance)" that was caused when PR133 was merged into dev.

One should first confirm that the current version of 'dev' gets an assertion failure when running (cosi-simgen::cosi-generate :nodes 8) [the 3rd line of simulation.md].

The problem (at least on my machine) is that the hostname for simulation was changed to "localhost" in many place, but a call to (MACHINE-INSTANCE) remained (in cosi-config.lisp).