### PR TITLE
added timeout for CoSi ; number of cores

### DIFF
--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -86,7 +86,8 @@ THE SOFTWARE.
       ;; for sim and debug
       
       (:make-block ()
-       (leader-exec node))
+       (let ((timeout (* 5 60))) ;; massive timeout during simulation (gets rid of :non-existent-actors messages?)
+         (leader-exec node timeout)))
 
       (:genesis-utxo (utxo)
        (record-new-utxo (bev (txout-hashlock utxo))))
@@ -1078,7 +1079,7 @@ bother factoring it with NODE-COSI-SIGNING."
 
 ;; ------------------------------------------------------------------------------------------------
 
-(defun leader-exec (node)
+(defun leader-exec (node timeout)
   (send *dly-instr* :clr)
   (send *dly-instr* :pltwin :histo-4)
   (pr "Assemble new block")
@@ -1095,7 +1096,7 @@ bother factoring it with NODE-COSI-SIGNING."
                     :witnesses        (map 'vector 'node-pkey *node-bit-tbl*)
                     :transactions     (get-transactions-for-new-block)))
         (self  (current-actor)))
-    (ac:self-call :cosi-sign-prepare self new-block 10)
+    (ac:self-call :cosi-sign-prepare self new-block timeout)
     (pr "Waiting for Cosi prepare")
     (labels
         ((wait-prep-signing ()

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -3,7 +3,8 @@
 (in-package :emotiq/sim)
 
 (defun initialize (&key (leader-node "127.0.0.1"))
-  (setf actors::*maximum-age* 120)
+  (setf actors::*maximum-age* 120
+        actors::*nbr-execs* 8)  ;; for sim, set to #cores (linux /usr/bin/nproc)
   (cosi-simgen::cosi-init leader-node)
   ;; Weird:  can't run cosi-generate as part of the process
   #+(or)


### PR DESCRIPTION
For simulation, added an override for the number of cores to node-sim.lisp/initialize an a timeout as a parameter to cosi-handlers.lisp/leader-exec.

A huge timeout (5 * 60) gets the simulator to complete with co-signers and no non-existent-actor messages.