### PR TITLE
Bring back block class now as eblock class

### DIFF
--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -6,43 +6,42 @@
 
 
                                                                                 ;
-(defclass block ()
+(defclass eblock ()
   ((protocol-version
-    :accessor protocol-version
     :initform 1
     :documentation 
       "Version of the protocol/software, an integer.")
 
    (epoch                               ; aka "height"
-    :initarg :epoch :accessor epoch
-    :initform nil 
+    :initarg :epoch
+    :initform 0
     :documentation
-      "The integer of the epoch that this block is a part of."
-      ;; height: "Position of block in the chain, an integer."
-      )
+    "Increasing integer count of epoch this block is part of. We keep
+     a single chain combining identity and ledger, unlike Byzcoin,
+     which keeps an outside identity blockchain with its epoch count
+     and an inside ledger blockchain with its height count. Thus,
+     epoch subsumes height.")
 
-   (block-hash
-    :accessor block-hash
-    :documentation "Hash of this block.")
    (prev-block-hash
-    :accessor prev-block-hash
+    :initform nil
     :documentation "Hash of previous block (nil for genesis block).")
 
-   (block-timestamp
-    :accessor block-timestamp
+   (timestamp
     :documentation 
-      "Approximate creation time in seconds since Unix epoch.")
+      "Approximate creation time in seconds since Unix epoch. The time zone is UTC.")
 
-   (block-signature
-    :accessor block-signature
+   (signature
+    :initform nil
+    :reader block-signature
     :documentation
     "A signature over the whole block authorizing all transactions.")
-   (block-signature-pkey
-    :accessor block-signature-pkey
+   (signature-pkey
+    :initform nil
+    :reader block-signature-pkey
     :documentation
     "Public key for block-signature")
-   (block-signature-bitmap
-    :accessor block-signature-bitmap
+   (signature-bitmap
+    :reader block-signature-bitmap
     :initform 0
     :documentation 
     "Use methods ith-witness-signed-p and set-ith-witness-signed-p OR,
@@ -51,27 +50,32 @@
      corresponds to a vector index, such that its state tells you
      whether that particular potential witness signed.")
 
-   (public-keys-of-witnesses
-    :accessor public-keys-of-witnesses
+   (witnesses
+    :initform nil
+    :reader block-witnesses
     :documentation
     "Sequence of public keys of validators 1:1 w/witness-bitmap slot.")
 
    (merkle-root-hash
-    :accessor merkle-root-hash
-    :documentation "Merkle root hash of block-transactions.")
+    :reader block-merkle-root-hash
+    :documentation "Merkle root hash of transactions.")
 
    ;; Transactions is generally what's considered the main contents of a block
    ;; whereas the rest of the above comprises what's known as the 'block header'
    ;; information.
    (transactions
-    :accessor transactions
-    :documentation "A sequence of transactions"))
+    :reader block-transactions
+    :documentation
+    "For now a sequence of transactions. Later, this may be changed to
+    be a merkle tree or simply allowed to be either a sequence or a
+    merkle tree as an alternative representation "))
   (:documentation "A block on the Emotiq blockchain."))
 
 
 
 (defvar *unix-epoch-ut* (encode-universal-time 0 0 0 1 1 1970 0)
-  "The Unix epoch as a Common Lisp universal time.")
+  "The Unix epoch as a Common Lisp universal time. (Note: implied time
+  zone is UTC.)")
 
 
 
@@ -89,18 +93,19 @@
 ;;; and they can require this order for a block to be considered valid.
 ;;; Software may also rely upon this order, e.g., as a search heuristic.
 
-(defun create-block (epoch prev-block transactions)
-  (let ((block (make-instance 'block :epoch epoch)))
-    (setf (prev-block-hash block) 
-          (if (null prev-block)
-              nil
-              (hash-block prev-block)))
-    (setf (merkle-root-hash block)
-          (compute-merkle-root-hash transactions))
-    (setf (transactions block) transactions)
-    (setf (block-timestamp block) 
-          (- (get-universal-time) *unix-epoch-ut*))
-    block))
+(defun create-block (prev-block? block-transactions)
+  (let ((blk (make-instance 'eblock)))
+    (with-slots (merkle-root-hash transactions timestamp)
+        blk
+      (setf timestamp (- (get-universal-time) *unix-epoch-ut*))
+      (setf transactions block-transactions)
+      (setf merkle-root-hash (compute-merkle-root-hash block-transactions))
+      (when prev-block? 
+        (with-slots (epoch prev-block-hash)
+            blk
+          (setf epoch (1+ (slot-value prev-block? 'epoch)))
+          (setf prev-block-hash (hash-block prev-block?))))
+      blk)))
 
 
 (defun hash-256 (&rest hashables)
@@ -124,11 +129,11 @@
   '(protocol-version 
     epoch
     prev-block-hash
-    block-timestamp
+    timestamp
 
-    block-signature
-    block-signature-pkey
-    block-signature-bitmap
+    signature
+    signature-pkey
+    signature-bitmap
 
     merkle-root-hash)
   "These slots are serialized and then hashed. The hash is stored as
@@ -157,17 +162,17 @@
    (if (consp transactions)
        ;; (optimized for list case)
        (loop for tx in transactions
-             as tx-out-id = (get-txid-out-id tx)
+             as tx-out-id = (get-transaction-id tx)
              collect tx-out-id)
        (loop for i from 0 below (length transactions)
              as tx = (elt transactions i)
-             as tx-out-id = (get-txid-out-id tx)
+             as tx-out-id = (get-transaction-id tx)
              collect tx-out-id))))
 
 
 
-(defun get-txid-out-id (transaction)
-  "Get the identifier of TRANSACTION an octet vector of length 32, which can be
+(defun get-transaction-id (transaction)
+  "Get the identifier of TRANSACTION, an octet vector of length 32, which can be
    used to hash the transactions leaves of the merkle tree to produce the
    block's merkle tree root hash. It represents H(PubKey, PedComm), or possibly
    a superset thereof."
@@ -223,3 +228,16 @@
           (dpb (if signed-p 1 0)
                (byte 1 i)
                witness-bitmap))))
+
+
+
+(defun update-block-signature (block sig bits)
+  (with-slots (signature signature-pkey signature-bitmap)
+      block
+    (setf signature (pbc:signed-message-sig sig))
+    (setf signature-pkey (pbc:signed-message-pkey sig))
+    (setf signature-bitmap bits)))
+
+;; Note: DBM had wrapped (base58 ) around all three values, but said
+;; that had only been for debugging, so I've removed that in this
+;; version.  -mhd, 5/2/18

--- a/src/Cosi-BLS/cosi-bls.asd
+++ b/src/Cosi-BLS/cosi-bls.asd
@@ -46,6 +46,7 @@ THE SOFTWARE.
                         :serial t
                         :components (#+CLOZURE (:file "clozure")
                                      (:file "cosi-blkdef")
+                                     (:file "block")
                                      (:file "cosi-keying")
 				     (:file "cosi-construction")
                                      (:file "cosi-netw-xlat")

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -316,26 +316,8 @@ Connecting to #$(NODE "10.0.1.6" 65000)
              (exit))
            ))))
    ))
-|#         
+|#
 
-;; --------------------------------------------------------------------
-;; define a blockchain block
-
-(defstruct bc-block
-  hash
-  protocol-version
-  epoch
-  timestamp
-  prev-block-hash
-  election-proof
-  leader-pkey
-  witnesses
-  transactions
-  signature
-  signature-pkey
-  signature-bitmap)
-
-(defvar *protocol-version* #x100)
 (defvar *election-proof*   nil)
 (defvar *leader*           nil)
 
@@ -348,29 +330,12 @@ Connecting to #$(NODE "10.0.1.6" 65000)
 (defvar *in-simulatinon-always-byz-ok* t) ;; set to nil for non-sim mode, forces consensus
 
 (defun signature-hash-message (blk)
-  (list
-   (bc-block-protocol-version blk)
-   (bc-block-epoch            blk)
-   (bc-block-timestamp        blk)
-   (bc-block-prev-block-hash  blk)
-   (bc-block-election-proof   blk)
-   (bc-block-leader-pkey      blk)
-   (bc-block-witnesses        blk)
-   (bc-block-transactions     blk)))
-
-(defun compute-block-hash (blk)
-  (apply 'hash/256
-         (nconc (signature-hash-message blk)
-                (list
-                 (bc-block-signature        blk)
-                 (bc-block-signature-pkey   blk)
-                 (bc-block-signature-bitmap blk)))
-         ))
+  (cosi/proofs:serialize-block-octets blk))
 
 (defun get-block-transactions (blk)
   "Right now it is a simple partially ordered list of transactions.
 Later it may become an ADS structure"
-  (bc-block-transactions blk))
+  (cosi/proofs:block-transactions blk))
 
 ;; --------------------------------------------------------------------
 
@@ -869,7 +834,7 @@ check that each TXIN and TXOUT is mathematically sound."
 (defun check-byz-threshold (bits blk)
   (or *in-simulatinon-always-byz-ok*
       (> (logcount bits)
-         (* 2/3 (length (bc-block-witnesses blk))))))
+         (* 2/3 (length (cosi/proofs:block-witnesses blk))))))
 
 (defun validate-cosi-message (node consensus-stage blk)
   (ecase consensus-stage
@@ -889,20 +854,22 @@ check that each TXIN and TXOUT is mathematically sound."
      ;; message is a block with multisignature check signature for
      ;; validity and then sign to indicate we have seen and committed
      ;; block to blockchain. Return non-nil to indicate willingness to sign.
-     (let ((signed (check-byz-threshold (bc-block-signature-bitmap blk) blk)))
+     (let ((signed (check-byz-threshold 
+                    (cosi/proofs:block-signature-bitmap blk)
+                    blk)))
        (unless signed
          (cleanup-mempool (get-block-transactions blk)))
        (when (and signed
                   (or (int= (node-pkey node) *leader*)
-                      (and (int= (bc-block-hash blk)
-                                 (compute-block-hash blk))
-                           (pbc:check-message (make-instance 'pbc:signed-message
-                                                             :msg  (signature-hash-message  blk)
-                                                             :pkey (bc-block-signature-pkey blk)
-                                                             :sig  (bc-block-signature      blk)))
-                           )))
+                      (int= (cosi/proofs:block-merkle-root-hash blk)
+                            (compute-merkle-root-hash
+                             (cosi/proofs:block-transactions blk)))
+                      (pbc:check-message (make-instance 'pbc:signed-message
+                                                        :msg  (signature-hash-message  blk)
+                                                        :pkey (cosi/proofs:block-signature-pkey blk)
+                                                        :sig  (cosi/proofs:block-signature blk)))))
          (push blk *blockchain*)
-         (setf (gethash (bc-block-hash blk) *blockchain-tbl*) blk)
+         (setf (gethash (cosi/proofs:hash-block blk) *blockchain-tbl*) blk)
          ;; clear out *mempool* and spent utxos
          (dolist (tx (get-block-transactions blk))
            (remove-tx-from-mempool tx)
@@ -1081,33 +1048,19 @@ bother factoring it with NODE-COSI-SIGNING."
 (defun leader-exec (node)
   (send *dly-instr* :clr)
   (send *dly-instr* :pltwin :histo-4)
-  (pr "Assemble new block")
-  (let ((new-block (make-bc-block
-                    :protocol-version *protocol-version*
-                    :epoch            (if *blockchain*
-                                          (1+ (bc-block-epoch (first *blockchain*)))
-                                        0)
-                    :timestamp        (uuid:make-v1-uuid)
-                    :prev-block-hash  (and *blockchain*
-                                           (bc-block-hash (first *blockchain*)))
-                    :election-proof   *election-proof*
-                    :leader-pkey      *leader*
-                    :witnesses        (map 'vector 'node-pkey *node-bit-tbl*)
-                    :transactions     (get-transactions-for-new-block)))
-        (self  (current-actor)))
+  (print "Assemble new block")
+  (let ((new-block (cosi/proofs:create-block (first *blockchain*) (get-transactions-for-new-block)))
+        (self      (current-actor)))
     (ac:self-call :cosi-sign-prepare self new-block 10)
-    (pr "Waiting for Cosi prepare")
+    (print "Waiting for Cosi prepare")
     (labels
         ((wait-prep-signing ()
            (recv
              ((list :answer (list :signature sig bits))
               (let ((*current-node* node))
-                (setf (bc-block-signature        new-block) (pbc:signed-message-sig  sig)
-                      (bc-block-signature-pkey   new-block) (pbc:signed-message-pkey sig)
-                      (bc-block-signature-bitmap new-block) bits
-                      (bc-block-hash             new-block) (compute-block-hash new-block))
+                (update-block-signature new-block sig bits)
                 (ac:self-call :cosi-sign-commit self new-block 10)
-                (pr "Waiting for Cosi commit")
+                (print "Waiting for Cosi commit")
                 (labels ((wait-cmt-signing ()
                            (recv
                              ((list :answer (list :signature _ bits))
@@ -1117,7 +1070,7 @@ bother factoring it with NODE-COSI-SIGNING."
                                        #+(or)
                                        (inspect new-block)
                                        (pr "Block committed to blockchain")
-                                       (pr (format nil "Block signatures = ~D" (logcount (bc-block-signature-bitmap new-block))))
+                                       (pr (format nil "Block signatures = ~D" (logcount (cosi/proofs:block-signature-bitmap new-block))))
                                        )
                                       
                                       (t

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -106,7 +106,7 @@
    :vec-repr
    :edec
    :pbc)
-  (:shadow :block)
+  (:shadow block)            ; used internally, not required for users
   (:import-from :ecc-crypto-b571
    :random-between)
   (:export
@@ -140,11 +140,30 @@
    :txout-secr-gamma
    )
   (:export
-   :block :protocol-version :epoch :prev-block :prev-block-hash
-   :merkle-root-hash :block-timestamp :transactions
-   :validator-keys-joining :validator-keys-leaving
-   :create-block :hash-block :serialize-block 
-   :compute-merkle-root-hash))
+   :eblock
+   :protocol-version
+   :epoch
+   :prev-block-hash
+   :merkle-root-hash
+   :timestamp
+   :transactions
+   :signature-bitmap
+   :witnesses
+   :signature-pkey
+   :signature
+   
+   :create-block
+   :hash-block 
+   :update-block-signature
+   :serialize-block-octets
+   :compute-merkle-root-hash
+
+   :block-transactions
+   :block-witnesses
+   :block-signature-bitmap
+   :block-signature-pkey
+   :block-signature
+   :block-merkle-root-hash))
 
 ;; from cosi-construction
 (defpackage :cosi-simgen
@@ -155,7 +174,6 @@
    :vec-repr
    :hash
    :cosi/proofs)
-  (:shadow :block)
   (:import-from :edwards-ecc
    :ed-add 
    :ed-sub 
@@ -199,8 +217,7 @@
   (:export
    :generate-tree
    :reconstruct-tree
-   :forwarding)
-  (:export :block))
+   :forwarding))
 
 (defpackage :cosi-keying
   (:use


### PR DESCRIPTION
Tested using simulation.md instructions.  Things seemed to run fine.

I noticed very first block created is not being added to list returned by (emotiq/sim:blocks). Not sure why that is.  But saw at least three blocks created.  Their epoch counts were 1, 2, 3, respectively.  They looked OK.