### PR TITLE
Add initial networking benchmark suite socket-actors-bench.lisp

### DIFF
--- a/src/gossip/socket-actors-bench.lisp
+++ b/src/gossip/socket-actors-bench.lisp
@@ -6,13 +6,13 @@
 
 (in-package :gossip)
 
-(defun benchmark-sendrecv-tcp-1 (&key (n 1) (seconds 1) (msgsize 100)
+(defun benchmark-sendrecv-tcp-1 (&key (connections 1) (seconds 1) (msgsize 100)
                                    (chatty 1.0)
                                    (encode :raw)
                                    (wait :nowait)
                                    (address "localhost"))
   "Run a benchmark of N client-server pairs sending unidirectional messages.
-   N is the number of client-server socket pairs to establish.
+   CONNECTIONS is the number of client-server socket pairs to establish.
    SECONDS is the duration of the benchmark.
    CHATTY is the chance of a socket being active on each iteration (0.0 - 1.0).
    ENCODE is :RAW or :SERIALIZE for how the message is encoded.
@@ -29,37 +29,59 @@
          (port (usocket:get-local-port listener))
          (clients '())
          (servers '())
+         (processes '()) ; processes that need to be shut down
          (messages 0))
     ;; Connnect client-server socket pairs.
-    (loop repeat n
+    (loop repeat connections
        do (push (usocket:socket-connect address port :nodelay :if-supported) clients)
        do (push (usocket:socket-accept listener) servers))
     ;; Helper functions
     (labels ((send ()
                (dolist (client clients)
-                 (when (< (random 1.0) chatty)
-                   (ecase encode
-                     (:raw
-                      (write-sequence msg (usocket:socket-stream client)))
-                     (:serialize
-                      (loenc:serialize msg (usocket:socket-stream client))))
-                   (finish-output (usocket:socket-stream client)))))
+                 (send-socket client)))
+             (send-socket (client)
+               (ecase encode
+                 (:raw
+                  (write-sequence msg (usocket:socket-stream client)))
+                 (:serialize
+                  (loenc:serialize msg (usocket:socket-stream client))))
+               (finish-output (usocket:socket-stream client)))
+             (serve-socket (server)
+               (unless (eq wait :thread)
+                 (ecase encode
+                   (:raw
+                    (read-sequence msg (usocket:socket-stream server)))
+                   (:serialize
+                    (loenc:deserialize (usocket:socket-stream server))))
+                 ;; Message received - Score a point.
+                 (incf messages)))
              (recv ()
-               (dolist (server (ecase wait
-                                 (:nowait servers)
-                                 (:usocket (usocket:wait-for-input servers))))
-                 (loop while (listen (usocket:socket-stream server))
-                      do (ecase encode
-                           (:raw
-                            (read-sequence msg (usocket:socket-stream server)))
-                           (:serialize
-                            (loenc:deserialize (usocket:socket-stream server))))
-                      ;; Message received - Score a point.
-                      (incf messages))))
+               (unless (eq wait :thread)
+                 (dolist (server (ecase wait
+                                   (:nowait servers)
+                                   (:usocket (usocket:wait-for-input servers))))
+                   (loop while (listen (usocket:socket-stream server))
+                      do (serve-socket server)))))
              (shutdown ()
                (usocket:socket-close listener)
+               (mapc #'mpcompat:process-kill processes) ; before closing sockets
                (mapc #'usocket:socket-close clients)
-               (mapc #'usocket:socket-close servers)))
+               (mapc #'usocket:socket-close servers))
+             (start-processes ()
+               (when (eq wait :thread)
+                 (dolist (server servers)
+                   (push (mpcompat:process-run-function
+                          "tcp benchmark server"
+                          nil
+                          (lambda () (loop do (serve-socket server))))
+                         processes))
+                 (dolist (client clients)
+                   (push (mpcompat:process-run-function
+                          "tcp benchmark client"
+                          nil
+                          (lambda () (loop do (send-socket client))))
+                         processes)))))
+      (start-processes)
       (unwind-protect 
            (loop with deadline = (+ (usec:get-time-usec) (* seconds 1000000))
               until (> (usec:get-time-usec) deadline)
@@ -69,7 +91,7 @@
         (shutdown)))))
 
 (defun suite-sendrecv-tcp-1 (&key
-                               (n '(1 10 25 50 100 200))
+                               (connections '(1 10 25 50 100 200))
                                (msgsize '(500 1000 1500 2000))
                                (chatty '(1.0))
                                (seconds '(1.0))
@@ -93,24 +115,24 @@
                      (make-broadcast-stream output-file *standard-output*)
                      *standard-output*)))
     ;; Populate TESTS with all permutations of variables.
-    (dolist (n n)
+    (dolist (n connections)
       (dolist (msgsize msgsize)
         (dolist (poll poll)
           (dolist (encode encode)
             (dolist (chatty chatty)
               (dolist (seconds seconds)
-                (push (list :n (max n 1) :msgsize msgsize :poll poll :encode encode :chatty chatty :seconds seconds) tests)))))))
+                (push (list :connections (max n 1) :msgsize msgsize :poll poll :encode encode :chatty chatty :seconds seconds) tests)))))))
     ;; Write prelude
     (format t "~&Running ~d tests~%" (length tests))
-    (format output "~&id,rate,n,msgsize,duration,poll,encode,chatty~%")
+    (format output "~&id,messages,connections,msgsize,duration,poll,encode,chatty~%")
     ;; Execute tests in a randomized order.
     (unwind-protect
          (dolist (test (alexandria:shuffle tests))
-           (destructuring-bind (&key n msgsize poll encode chatty seconds) test
+           (destructuring-bind (&key connections msgsize poll encode chatty seconds) test
              (format output "~&~d,~d,~d,~d,~d,~a,~a,~f~%"
                      (incf id)
-                     (benchmark-sendrecv-tcp-1 :n n :msgsize msgsize :seconds seconds)
-                     n msgsize seconds poll encode chatty)
+                     (benchmark-sendrecv-tcp-1 :connections connections :msgsize msgsize :seconds seconds :wait poll)
+                     connections msgsize seconds poll encode chatty)
              (finish-output output)))
       (unless (null output-file) (close output-file)))
     (format t "~&Benchmark suite completed.~%")))

--- a/src/gossip/socket-actors-bench.lisp
+++ b/src/gossip/socket-actors-bench.lisp
@@ -1,0 +1,117 @@
+;;; socket-actor-bench.lisp
+;;; Benchmarks of actor sockets, without gossip
+
+(ql:quickload :gossip)
+(ql:quickload :ironclad)
+
+(in-package :gossip)
+
+(defun benchmark-sendrecv-tcp-1 (&key (n 1) (seconds 1) (msgsize 100)
+                                   (chatty 1.0)
+                                   (encode :raw)
+                                   (wait :nowait)
+                                   (address "localhost"))
+  "Run a benchmark of N client-server pairs sending unidirectional messages.
+   N is the number of client-server socket pairs to establish.
+   SECONDS is the duration of the benchmark.
+   CHATTY is the chance of a socket being active on each iteration (0.0 - 1.0).
+   ENCODE is :RAW or :SERIALIZE for how the message is encoded.
+   MSGSIZE is the message size in octets.
+   ADDRESS is the network interface to bind sockets on.
+   Returns the rate of client->server messages per second as the benchmark score."
+  (let* ((msg (coerce (ironclad:random-data msgsize)
+                      (ecase encode
+                        (:raw '(simple-array (unsigned-byte 8) *))
+                        (:serialize 'string))))
+         (listener (usocket:socket-listen address 0
+                                          :element-type '(unsigned-byte 8)
+                                          :reuse-address t))
+         (port (usocket:get-local-port listener))
+         (clients '())
+         (servers '())
+         (messages 0))
+    ;; Connnect client-server socket pairs.
+    (loop repeat n
+       do (push (usocket:socket-connect address port :nodelay :if-supported) clients)
+       do (push (usocket:socket-accept listener) servers))
+    ;; Helper functions
+    (labels ((send ()
+               (dolist (client clients)
+                 (when (< (random 1.0) chatty)
+                   (ecase encode
+                     (:raw
+                      (write-sequence msg (usocket:socket-stream client)))
+                     (:serialize
+                      (loenc:serialize msg (usocket:socket-stream client))))
+                   (finish-output (usocket:socket-stream client)))))
+             (recv ()
+               (dolist (server (ecase wait
+                                 (:nowait servers)
+                                 (:usocket (usocket:wait-for-input servers))))
+                 (loop while (listen (usocket:socket-stream server))
+                      do (ecase encode
+                           (:raw
+                            (read-sequence msg (usocket:socket-stream server)))
+                           (:serialize
+                            (loenc:deserialize (usocket:socket-stream server))))
+                      ;; Message received - Score a point.
+                      (incf messages))))
+             (shutdown ()
+               (usocket:socket-close listener)
+               (mapc #'usocket:socket-close clients)
+               (mapc #'usocket:socket-close servers)))
+      (unwind-protect 
+           (loop with deadline = (+ (usec:get-time-usec) (* seconds 1000000))
+              until (> (usec:get-time-usec) deadline)
+              for iterations from 0
+              do  (send) (recv)
+              finally (return messages))
+        (shutdown)))))
+
+(defun suite-sendrecv-tcp-1 (&key
+                               (n '(1 10 25 50 100 200))
+                               (msgsize '(500 1000 1500 2000))
+                               (chatty '(1.0))
+                               (seconds '(1.0))
+                               (encode '(:raw :serialize))
+                               (poll '(:nowait :usocket))
+                               output-filename)
+  "Run a suite of benchmark-sendrecv-tcp-1 tests.
+   Keyword arguments provide the set of values for each variable.
+   All permutations are tested and the order of tests is shuffled so
+   that background noise (load on machine, heap fragmentation, etc) is
+   randomly distributed between all variables.
+   
+   Output is written to standard output and also OUTPUT-FILENAME if supplied.
+   See BENCHMARK-SENDRECV-TCP-1 for more parameter details."
+  (let* ((id 0)
+         (tests '())
+         (output-file (if output-filename
+                          (open output-filename :direction :output :if-exists :supersede)
+                          nil))
+         (output (if output-file
+                     (make-broadcast-stream output-file *standard-output*)
+                     *standard-output*)))
+    ;; Populate TESTS with all permutations of variables.
+    (dolist (n n)
+      (dolist (msgsize msgsize)
+        (dolist (poll poll)
+          (dolist (encode encode)
+            (dolist (chatty chatty)
+              (dolist (seconds seconds)
+                (push (list :n (max n 1) :msgsize msgsize :poll poll :encode encode :chatty chatty :seconds seconds) tests)))))))
+    ;; Write prelude
+    (format t "~&Running ~d tests~%" (length tests))
+    (format output "~&id,rate,n,msgsize,duration,poll,encode,chatty~%")
+    ;; Execute tests in a randomized order.
+    (unwind-protect
+         (dolist (test (alexandria:shuffle tests))
+           (destructuring-bind (&key n msgsize poll encode chatty seconds) test
+             (format output "~&~d,~d,~d,~d,~d,~a,~a,~f~%"
+                     (incf id)
+                     (benchmark-sendrecv-tcp-1 :n n :msgsize msgsize :seconds seconds)
+                     n msgsize seconds poll encode chatty)
+             (finish-output output)))
+      (unless (null output-file) (close output-file)))
+    (format t "~&Benchmark suite completed.~%")))
+  


### PR DESCRIPTION
This file defines a simple transport-level benchmark called
'sendrecv-tcp-1' that opens a set of client-server socket pairs and
sends messages from the client to the server.

The basic benchmark function GOSSIP::BENCHMARK-SENDRECV-TCP-1 takes
keyword parameters to control how the test is executed. This is
especially meant to test the performance of different socket polling
strategies, message serialization methods, etc, with different levels
of load.

The higher-level function GOSSIP::SUITE-SENDRECV-TCP-1 can execute a
complete test campaign for the permutations of given variable values.
The results are formatted as CSV for separate analysis.

Notes:

- This benchmark is operating at the socket layer and does not
  exercise higher-level functionality from socket-actors and gossip.
- The benchmark runs all clients and servers on a single Lisp thread.
- This initial implementation has not yet been sanity-checked with
  tools like system call profilers and so may contain egregious bugs.

### Testing

This is easy to test:
- Load the file `gossip/socket-actors-bench.lisp`.
- Run `(gossip::suite-sendrecv-tcp-1)`.

You may need to check your `ulimit -n` for maximum open file descriptors if you are testing with many sockets at once.

### Example

Here is an example set of results in CSV format: [gist](https://gist.github.com/lukego/2fdba52a042aaaf5f83ac7b02686b0f7). These are from a campaign running on CCL/Linux that tested many different levels of socket concurrency and many different levels of "chattiness" to see how this affects throughput and how much difference the polling method makes (comparing only two basic polling methods, NOWAIT that simply receives on every socket in a loop, and USOCKET that calls `select()` under the hood.)

The CSV results can then be analyzed in weird and wonderful ways. Here is one (click to zoom):

![rplot15](https://user-images.githubusercontent.com/13791/40424915-305a5ec8-5e97-11e8-831d-29deaca08358.png)

Here is one interpretation:

- The panels each show a different level of "chattiness" from 0.1 where 10% of sockets have data on each iteration to 1.0 where all sockets have data.
- The Y axis shows throughput in total messages/second transferred across client/server pairs.
- The X axis shows the number of client/server socket pairs that are open concurrently.
- The color of each point shows the polling method that was used.
- The slope from left to right shows how performance changes (degrades) as more sockets are opened.
- The points exhibit some jitter. Each point in this dataset represents one second of runtime and this can be significantly impacted by background events such as garbage collections.

This graph seems to suggest that with usocket on CCL/Linux performance falls fairly gradually as the number of sockets increase, with relatively little difference between 1 socket and 100 sockets, and that there is not much practical difference between these polling methods at the measures levels of chattiness.

Quite a few data points are down ~10-20% seemingly at random. My hypothesis is that this is due to gabarge collection. In the future this could either be controlled for explicitly, or averaged out with longer tests, or simply ignored.