### PR TITLE
[#157840690]  simplify conditionalization for install-actor-system

### DIFF
--- a/src/Actors/actors-startup.lisp
+++ b/src/Actors/actors-startup.lisp
@@ -217,12 +217,11 @@ THE SOFTWARE.
     (install-actor-directory)
     (install-actor-printer)))
 
-#+(AND (NOT :COM.RAL)
-       (or :LISPWORKS :ALLEGRO :OPENMCL))
+#-:lispworks
 (eval-when (:load-toplevel :execute)
   (install-actor-system))
 
-#+(AND :LISPWORKS :COM.RAL)
+#+:lispworks
 (let ((lw:*handle-existing-action-in-action-list* '(:warn :skip)))
   
   (lw:define-action "Initialize LispWorks Tools"


### PR DESCRIPTION
Fix LispWorks delivery by using ACTION mechanism under LispWorks, but `eval-when` in other implementations.