### PR TITLE
Remove all top-level uses of PBC:MAKE-KEY-PAIR

### DIFF
--- a/src/Cosi-BLS/cosi-netw-xlat.lisp
+++ b/src/Cosi-BLS/cosi-netw-xlat.lisp
@@ -255,22 +255,29 @@ THE SOFTWARE.
 (defun port-router (buf)
   (send *handler* (copy-seq buf)))
 
-(defvar *keys*   (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid))))
 (defvar *sender* (make-actor (lambda (ip port packet)
                                ;; (pr (format nil "~A ~A ~D ~A" ip port (length packet) packet))
                                (internal-send-socket ip port packet))))
-  
+
 (defun shutdown-server (&optional (port *cosi-port*))
   (when *socket-open*
     (setf *socket-open* nil)
     (ac:send *sender* *local-ip* port "ShutDown")))
 
-(defmethod socket-send (ip port dest msg)
-  (let* ((payload (make-hmac (list* dest msg)
-                             (pbc:keying-triple-pkey *keys*)
-                             (pbc:keying-triple-skey *keys*)))
-         (packet  (loenc:encode payload)))
-    (ac:send *sender* ip port packet)))
+;;; For binary delivery, we need to allocate keypair memory at
+;;; runtime.  
+(let (hmac-keypair)
+  (defun hmac-keypair ()
+    (unless hmac-keypair
+      (setf hmac-keypair
+            (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid)))))
+    hmac-keypair)
+  (defmethod socket-send (ip port dest msg)
+    (let* ((payload (make-hmac (list* dest msg)
+                               (pbc:keying-triple-pkey (hmac-keypair))
+                               (pbc:keying-triple-skey (hmac-keypair))))
+           (packet  (loenc:encode payload)))
+      (ac:send *sender* ip port packet))))
 
 #|
 (defmethod socket-send :around (ip port dest msg)

--- a/src/Crypto/finite-fields/fields.lisp
+++ b/src/Crypto/finite-fields/fields.lisp
@@ -4,9 +4,15 @@
 
 (in-package :pbc/x)
 
+#|  FIXME:  PBC:MAKE-KEY-PAIR cannot be called at compile time for delivery under LispWorks
+
+The following code doesn't appear to be referenced
+
 (defparameter k (make-key-pair :dave))
 (defparameter pkey (keying-triple-pkey k))
 (defparameter skey (keying-triple-skey k))
+
+|#
 
 (defparameter beta   76600213043964638334639432839350561620586998450651561245322304548751832163977)
 (defparameter alpha0 82889197335545133675228720470117632986673257748779594473736828145653330099944)

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -37,8 +37,7 @@
                 :components ((:file "blockchain")))))
                                        
 (defsystem "emotiq/startup"
-  ;; add gossip here soon:
-  :depends-on (emotiq/blockchain crypto-pairings core-crypto)
+  :depends-on (crypto-pairings)
   :components ((:module source
                 :pathname "./"
                 :serial t

--- a/src/gossip/gossip.lisp
+++ b/src/gossip/gossip.lisp
@@ -2030,17 +2030,22 @@ gets sent back, and everything will be copacetic.
 ;; We need to authenticate all messages being sent over socket ports
 ;; from this running Lisp image. Give us some signing keys to do so...
 
-(defvar *this-lisp-key*
-  (pbc:make-key-pair (list :lisp-authority (uuid:make-v1-uuid))))
-
-(defun sign-message (msg)
-  "Sign and return an authenticated message packet. Packet includes
+;;; The need for this is rather dubious.  No one other than the
+;;; signing node can authenticate this HMAC. 
+(let (hmac-keypair)
+  (defun hmac-keypair ()
+    (unless hmac-keypair
+      (setf hmac-keypair
+            (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid))))
+      hmac-keypair))
+  (defun sign-message (msg)
+    "Sign and return an authenticated message packet. Packet includes
 original message."
-  (assert (pbc:check-public-key (pbc:keying-triple-pkey *this-lisp-key*)
-                                (pbc:keying-triple-sig  *this-lisp-key*)))
-  (pbc:sign-message msg
-                    (pbc:keying-triple-pkey *this-lisp-key*)
-                    (pbc:keying-triple-skey *this-lisp-key*)))
+    (assert (pbc:check-public-key (pbc:keying-triple-pkey (hmac-keypair)
+                                  (pbc:keying-triple-sig  (hmac-keypair)))))
+    (pbc:sign-message msg
+                      (pbc:keying-triple-pkey (hmac-keypair))
+                      (pbc:keying-triple-skey (hmac-keypair)))))
 
 ;; ------------------------------------------------------------------------------
 

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -53,7 +53,7 @@ witnesses."
     (emotiq/cli:main)))
 
 (defvar *genesis-account*
-  (pbc:make-key-pair :genesis)
+  nil
   "Genesis account.")
 
 (defvar *genesis-output*
@@ -117,13 +117,26 @@ witnesses."
   (ac:pr "force-epoch-end")
   (cosi-simgen:send cosi-simgen:*leader* :make-block))
 
-
-(defparameter *user-1* (pbc:make-key-pair :user-1))
-(defparameter *user-2* (pbc:make-key-pair :user-2))
-(defparameter *user-3* (pbc:make-key-pair :user-3))
+(defparameter *user-1* nil)
+(defparameter *user-2* nil)
+(defparameter *user-3* nil)
 (defparameter *tx-1* nil)
 (defparameter *tx-2* nil)
 (defparameter *tx-3* nil)
+
+(defun ensure-simulation-keys ()
+  (unless (and *genesis-account* *user-1* *user-2* *user-3*)
+    (setf *genesis-account*
+          (pbc:make-key-pair :genesis)
+          
+          *user-1*
+          (pbc:make-key-pair :user-1)
+
+          *user-2*
+          (pbc:make-key-pair :user-2)
+          
+          *user-3*
+          (pbc:make-key-pair :user-3))))
 
 ; test helper - in real life, we would already know the pkey of the destination,
 ; here we have special variables holding the various test users
@@ -148,12 +161,12 @@ This will spawn an actor which will asynchronously do the following:
 "
 
   (declare (ignore amount))
+  (ensure-simulation-keys)
 
   (setf *genesis-output* nil
         *tx-1*           nil
         *tx-2*           nil
         *tx-3*           nil)
-
 
   (cosi-simgen:reset-nodes) 
 

--- a/src/startup.lisp
+++ b/src/startup.lisp
@@ -2,13 +2,9 @@
 
 (defun main (&optional how-started-message?)
   (message-running-state how-started-message?)
-  (pbc:init-pairing)
-  (let ((context (start-blockchain-context)))
-    (with-blockchain-context (context)
-			     (let ((genesis-block (make-genesis-block)))
-			       (format *standard-output*
-				       "~&Here is the first transaction of the genesis block:~%  ~a~%"
-				       genesis-block)))))
+  (format *standard-output* "Making key pair…")
+  (let ((keypair (pbc:make-key-pair :foo)))
+    (format *standard-output* "  Created ~a~&" keypair)))
 
 (defun message-running-state (&optional how-started-message?)
   (format *standard-output* "~%Running ~a in ~a~%with args [~a]~%"


### PR DESCRIPTION
Such usage results in segmentation violations at production runtime,
as top-level references during LispWorks delivery process refer to
malloc()'d memory.