### PR TITLE
bitcoin-style base58-check p2pkh addresses

### DIFF
--- a/src/Cosi-BLS/address.lisp
+++ b/src/Cosi-BLS/address.lisp
@@ -1,0 +1,152 @@
+;;;; address.lisp
+
+(in-package :cosi/proofs)
+
+
+
+;;;; Addresses: Public Key Hashes in Emotiq
+
+;;; Hashed public keys are presented as `addresses'.  An `address' for a public
+;;; key is in general produced as follows:
+;;;
+;;; First, it is hashed irreversibly, and then encoded in a user friendly
+;;; manner, that is, shorter; with characters easily typed, read, and
+;;; distinguishable by humans in nearly all computing environments; with a
+;;; checksum to catch the vast majority of simple mistakes in typing; and with a
+;;; "version" (or "network") prefix that helps identify which use it is for (and
+;;; also which cryptocurrency it's for (e.g., where Bitcoin uses 0x00, Litecoin
+;;; uses 0x30).
+
+;;; As many other cryptocurrencies have done, we simply adopt the Bitcoin
+;;; specification for addresses, known as Base58Check Encoding. The only thing
+;;; that we makes our addresses distinct is that we use unique version/network
+;;; prefix. (We hope ours is unique. There does not seem to be any central
+;;; registry.  If there is, we do not know of one at this time, May 27, 2018.)
+
+;;; So for the Bitcoin address the details are as follows. First we hash the
+;;; public key with SHA2/256. The resulting hash is shortened with a second hash
+;;; of RIPEMD160, getting bits down to 160 or 20 bytes (octets).  The version
+;;; prefix octet is prepended on to the front of the resulting hash result,
+;;; viewed as an octet vector.  The resulting vector V gets a 4-element checksum
+;;; vector appended containing elements created as follows: take a double
+;;; sha2/256 hash of V, and take the first 4 elements of the result viewed as an
+;;; octet vector, and then append that octet vector at the end of V. Finally,
+;;; that entire result is base58-encoded as a string, yielding the final result.
+;;;
+;;; Here is a more concise summary:
+;;;
+;;;   Public Key => SHA-2/256 => RIPEMD160 => Base58Check Encode version prefix
+
+;;; The byte (octet) layout ends up as follows:
+;;;
+;;;   [version] [RIPEMD160 hash] [checksum]
+;;;       1           20              4
+
+
+;;; The constants +mainnet-version-for-public-key-to-address+ and
+;;; +testnet-version-for-public-key-to-address+ are to be used for mainnet and
+;;; testnet deployments, respectively, as the version (network) prefix octet.
+
+;;; The values chosen are somewhat arbitrary but with the following constraints:
+;;;
+;;;   (1) cannot conflict with prominent well-known Bitcoin values, notably
+;;;
+;;;         0x00 0x03 0x6F 0x80 0x0142 0x6F 0x00;
+;;;
+;;;   (2) ideally, ought not to conflict other prominant cryptocurrencies'
+;;;   established mainnet p2pkh version prefixes, notably
+;;;
+;;;     Lightcoin: 176; Doge: 30; Dash: 76
+;;;
+;;;   (3) initial character of resulting address string must be unique between
+;;;   our mainnet and testnet, e.g., mainnet starts with "2" and testnet starts
+;;;   with "y".
+
+;;; The parameter *default-net-for-public-key-to-address*, which defaults to
+;;; :TEST, says which one is to be preferred if neither is specified.  It should
+;;; be one of two values: :TEST or :MAIN. Although the default for this is
+;;; currently :TEST, this may be changed in the future to :MAIN.
+
+(defparameter +mainnet-version-for-public-key-to-address+ #xE0
+  ;; 224 decimal (address starts with "2", ... [others?])
+  "Version prefix octet for mainnet public key hash address creation.")
+
+(defparameter +testnet-version-for-public-key-to-address+ #x8d
+  ;; 141 decimal (address starts with "y", ... [others?])
+  "Version prefix octet for mainnet public key hash address creation.")
+
+(defparameter *default-net-for-public-key-to-address* :test
+  "Which net to prefer creating addresses for public keys, :test or :main.")
+
+;; Figure out the how you figure out the possible starting characters and
+;; document them! Also, check if there are any conflicts with Bitcoin or other
+;; currencies to be concerned with. NB: currently defaulting to testnet. Later,
+;; consider changing later in project to mainnet. -mhd, 5/27/18
+
+
+
+(defun encode-address (hash160 version-octet)
+  "Takes HASH160, a 20 byte RIPEMD160 hash of a public key, and a version octet,
+  returns a corresponding string in Bitcoin address Base58check format."
+  (let* ((prefix+data
+           (concatenate
+            'ub8-vector `#(,version-octet) (vec-repr:bev-vec hash160)))
+         (checksum-vec
+           (checksum-hash-address prefix+data))
+         ;; tack that checksum onto the end of the prefix+data
+         (prefix+data+checksum
+           (concatenate 'ub8-vector prefix+data checksum-vec)))
+    (vec-repr:base58-str prefix+data+checksum)))
+
+
+
+(defun checksum-hash-address (prefix+data)  
+  "Get a checksum for PREFIX+DATA, an octet vector composed of a single octet
+   with the version prefix followed by the 20 octets of hash data. This returns
+   an octet vector of the first 4 bytes of the double sha2/256 hash of
+   prefix+data."
+  (subseq (vec-repr:bev-vec
+           (hash:hash/sha2/256 (hash:hash/sha2/256 prefix+data)))
+          0 4))
+
+
+
+(defun public-key-to-address (public-key &key net override-version)
+  "Produce an address for PUBLIC-KEY. Keyword :NET can be either :MAIN for
+   mainnet, :TEST for testnet, or nil to default.  The version prefix is usually
+   determined by the net. However, if OVERRIDE-VERSION is specified non-nil, it
+   should be a version prefix octet to be used, and in that case it is used
+   instead. This is intended to be used as a testing and debugging feature."
+  (encode-address
+   (hash:hash/ripemd/160 (hash:hash/sha2/256 public-key))
+   (or override-version
+       (ecase (or net *default-net-for-public-key-to-address*)
+         (:main +mainnet-version-for-public-key-to-address+)
+         (:test +testnet-version-for-public-key-to-address+)))))
+
+;; Note: the :override-version keyword lets you take a public key and version
+;; prefix and test results from any crypto currency and compare results. See
+;; t/address-tests.lisp for examples of usage and additional test notes.
+
+
+;; Background and Additional notes:
+
+;; Useful reference: a survey of various cryptocurrencies and their address formats
+;; 
+;;   https://blockgeeks.com/guides/blockchain-address-101/
+;;
+;; Here's what they are for Bitcoin:
+;;
+;; Bitcoin Address: 0x00
+;; Pay to Script Hash address: 0x03
+;; Bitcoin testnet address: 0x6F
+;; Private key WIF: 0x80
+;; BIP-38 Encrypted private key: 0x0142
+
+;; Here's a longer exhaustive list:
+;;
+;;   https://en.bitcoin.it/wiki/List_of_address_prefixes
+;;
+;; Bitcoin reference on Base 58:
+;;
+;;   https://en.bitcoin.it/wiki/Base58Check_encoding#Creating_a_Base58Check_string

--- a/src/Cosi-BLS/cosi-bls-tests.asd
+++ b/src/Cosi-BLS/cosi-bls-tests.asd
@@ -11,6 +11,7 @@
                 :pathname "t/"
                 :depends-on (package)
                 :components ((:file "cosi-tests")
+                             (:file "address-tests")
                              (:file "ranges")))))
 
   

--- a/src/Cosi-BLS/cosi-bls.asd
+++ b/src/Cosi-BLS/cosi-bls.asd
@@ -45,6 +45,7 @@ THE SOFTWARE.
                         :pathname "./"
                         :serial t
                         :components (#+CLOZURE (:file "clozure")
+                                     (:file "address")
                                      (:file "cosi-blkdef")
                                      (:file "block")
                                      (:file "cosi-keying")

--- a/src/Cosi-BLS/cosi-netw-xlat.lisp
+++ b/src/Cosi-BLS/cosi-netw-xlat.lisp
@@ -204,7 +204,7 @@ THE SOFTWARE.
 (defun shutdown-server (&optional (port *cosi-port*))
   (when *socket-open*
     (setf *socket-open* nil)
-    (send *sender *local-ip* port "ShutDown")))
+    (send *sender* *local-ip* port "ShutDown")))
 
 ;;; For binary delivery, we need to allocate keypair memory at
 ;;; runtime.  

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -158,6 +158,8 @@
    :txout-secr-gamma
    )
   (:export
+   public-key-to-address)
+  (:export
    :eblock
    :protocol-version
    :epoch

--- a/src/Cosi-BLS/t/address-tests.lisp
+++ b/src/Cosi-BLS/t/address-tests.lisp
@@ -1,0 +1,48 @@
+;;;; address-tests.lisp
+
+(in-package :cosi-tests)
+
+(define-test public-key-to-key-hash-as-address-test
+  (let* ((public-key-as-hex-string
+           "0433F8C523B3FF52F0A515DD19EB88B1356BED642F5B9A55AE34D7481FE2EED2D36BDACAFD1A400910CDD1F3BB79A8C4D090C37180156BE25D2801D53DFA646066")
+         (public-key-byte-vector
+           (ironclad:hex-string-to-byte-array public-key-as-hex-string))
+         (bitcoin-version #x00)
+         (should-be-bitcoin-address
+           "1ABD7Te3tqtMmdmYh432fSyB2fX3juS475")
+         (should-be-mainnet-address
+           "2ZHtKfnQawFgcxizxB2eRHXwQ1fEM62RSiT")
+         (should-be-testnet-address
+           "ytqFwmfg1HDu5kRm9Czy38M6mnr45QaA3L"))
+    (print "Public Key to Key Hash as Address Test (Base58Check Encoding)")
+    (assert-equal
+     should-be-bitcoin-address 
+     (public-key-to-address
+      public-key-byte-vector :override-version bitcoin-version)
+     'should-be-bitcoin-address)
+    (assert-equal 
+     should-be-mainnet-address
+     (public-key-to-address public-key-byte-vector :net :main)
+     'should-be-mainnet-address)
+    (assert-equal 
+     should-be-testnet-address
+     (public-key-to-address public-key-byte-vector :net :test)
+     'should-be-testnet-address)))
+
+
+;; Test notes: it may be helpful to test individual components of the
+;; address.lisp code with the handy address tester here:
+;;
+;;   http://gobittest.appspot.com/Address 
+;;
+;; E.g., you can copy/paste what's in the blank labelled "1 - Public ECDSA Key"
+;; into a Lisp string assigned to, say, variable *S*, and then you can do
+;;
+;;   (public-key-to-address (ironclad:hex-string-to-byte-array *s*) :override-version 0)
+;;
+;; Try with *S* = "0433F8C523B3FF52F0A515DD19EB88B1356BED642F5B9A55AE34D7481FE2EED2D36BDACAFD1A400910CDD1F3BB79A8C4D090C37180156BE25D2801D53DFA646066"
+;; Result should be: "1ABD7Te3tqtMmdmYh432fSyB2fX3juS475"
+;;
+;; You can also put the above (or some other) public key into blank labelled "1
+;; - Public ECDSA Key" at the test site and click the "send" button to verify
+;; that it gets the same result.

--- a/src/Crypto/ecc-package.lisp
+++ b/src/Crypto/ecc-package.lisp
@@ -102,6 +102,8 @@ THE SOFTWARE.
    :hash-val
    :hash-bytes
    :hash-length
+   :hash/ripemd/160
+   :hash/sha2/256
    :hash/256
    :hash/384
    :hash/512

--- a/src/Crypto/hash.lisp
+++ b/src/Crypto/hash.lisp
@@ -32,6 +32,12 @@ THE SOFTWARE.
   ((val :reader  hash-val
         :initarg :val)))
 
+(defclass hash/ripemd/160 (hash)
+  ())
+
+(defclass hash/sha2/256 (hash)
+  ())
+
 (defclass hash/256 (hash)
   ())
 
@@ -76,6 +82,37 @@ THE SOFTWARE.
    (loenc:encode x)))
 
 ;; -------------------------------------------------
+
+(defun local-ripemd/160-buffers (&rest bufs)
+  (let ((dig (ironclad:make-digest :ripemd-160)))
+    (dolist (buf bufs)
+      (ironclad:update-digest dig buf))
+    (ironclad:produce-digest dig)))
+
+(defun hash/ripemd/160 (&rest args)
+  ;; produce a UB8V of the args
+  (let ((hv  (apply 'local-ripemd/160-buffers
+                    (mapcar 'hashable args))))
+    (values (make-instance 'hash/ripemd/160
+                           :val (make-instance 'bev
+                                               :vec hv))
+            (length hv))))
+
+(defun local-sha2/256-buffers (&rest bufs)
+  (let ((dig (ironclad:make-digest :sha256))) ; sha2/256
+    (dolist (buf bufs)
+      (ironclad:update-digest dig buf))
+    (ironclad:produce-digest dig)))
+
+(defun hash/sha2/256 (&rest args)
+  ;; produce a UB8V of the args
+  (let ((hv  (apply 'local-sha2/256-buffers
+                    (mapcar 'hashable args))))
+    (values (make-instance 'hash/sha2/256
+                           :val (make-instance 'bev
+                                               :vec hv))
+            (length hv))))
+
 
 (defun local-sha3/256-buffers (&rest bufs)
   (let ((dig (ironclad:make-digest :sha3/256)))

--- a/src/Crypto/tests/crypto-tests.lisp
+++ b/src/Crypto/tests/crypto-tests.lisp
@@ -91,3 +91,47 @@
     (assert-true (check-confidential-purchase ppurch
                                               cost fees))))
 |#
+
+
+
+;;;; Base58 Tests
+
+;;; Adapted from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
+
+(defparameter *base58-test-inputs-and-expected-outputs*
+  '(("" "")
+    ("61" "2g")
+    ("626262" "a3gV")
+    ("636363" "aPEr")
+    ("73696d706c792061206c6f6e6720737472696e67" "2cFupjhnEsSn59qHXstmK2ffpLv2")
+    ("00eb15231dfceb60925886b67d065299925915aeb172c06647" "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L")
+    ("516b6fcd0f" "ABnLTmg")
+    ("bf4f89001e670274dd" "3SEo3LWLoPntC")
+    ("572e4794" "3EFU7m")
+    ("ecac89cad93923c02321" "EJDM8drfXA6uyA")
+    ("10c8511e" "Rt5zm")
+    ("00000000000000000000" "1111111111")
+    ("000111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5" "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
+    ("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff" "1cWB5HCBdLjAuqGGReWE3R3CguuwSjw6RHn39s2yuDRTS5NsBgNiFpWgAnEx6VQi8csexkgYw3mdYrMHr8x9i7aEwP8kZ7vccXWqKDvGv3u1GxFKPuAkn8JCPPGDMf3vMMnbzm6Nh9zh1gcNsMvH3ZNLmP5fSG6DGbbi2tuwMWPthr4boWwCxf7ewSgNQeacyozhKDDQQ1qL5fQFUW52QKUZDZ5fw3KXNQJMcNTcaB723LchjeKun7MuGW5qyCBZYzA1KjofN1gYBV3NqyhQJ3Ns746GNuf9N2pQPmHz4xpnSrrfCvy6TVVz5d4PdrjeshsWQwpZsZGzvbdAdN8MKV5QsBDY")))
+
+(defun base58-tests ()
+  (loop for (in-hex-string expected-out-base58-string)
+          in *base58-test-inputs-and-expected-outputs*
+        as in-bv = (ironclad:hex-string-to-byte-array in-hex-string)
+        as out-base58-string = (vec-repr:base58-str in-bv)
+        initially (format t "~%Base58-test~%")
+        do (format t "In: ~s~%  => (expect:) ~s~%" 
+                   in-hex-string expected-out-base58-string)
+           ;; make less verbose after the dust settles! -mhd, 5/29/18
+           (unless (equal out-base58-string 
+                          expected-out-base58-string)
+             (cerror "Continue as usual"
+                     "Unexpected results.~%   ~s => ~s~%  Expected: ~s."
+                     in-hex-string out-base58-string
+                     expected-out-base58-string))
+           (assert-equal out-base58-string 
+                         expected-out-base58-string)))
+
+
+(define-test base58-tests
+  (base58-tests))

--- a/src/Crypto/tests/crypto-tests.lisp
+++ b/src/Crypto/tests/crypto-tests.lisp
@@ -114,6 +114,10 @@
     ("000111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5" "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
     ("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff" "1cWB5HCBdLjAuqGGReWE3R3CguuwSjw6RHn39s2yuDRTS5NsBgNiFpWgAnEx6VQi8csexkgYw3mdYrMHr8x9i7aEwP8kZ7vccXWqKDvGv3u1GxFKPuAkn8JCPPGDMf3vMMnbzm6Nh9zh1gcNsMvH3ZNLmP5fSG6DGbbi2tuwMWPthr4boWwCxf7ewSgNQeacyozhKDDQQ1qL5fQFUW52QKUZDZ5fw3KXNQJMcNTcaB723LchjeKun7MuGW5qyCBZYzA1KjofN1gYBV3NqyhQJ3Ns746GNuf9N2pQPmHz4xpnSrrfCvy6TVVz5d4PdrjeshsWQwpZsZGzvbdAdN8MKV5QsBDY")))
 
+(setq lisp-unit:*print-failures* t)     ; <= consider removing or move
+                                        ; elsewhere when dust settles?
+                                        ; -mhd, 5/29/18
+
 (defun base58-tests ()
   (loop for (in-hex-string expected-out-base58-string)
           in *base58-test-inputs-and-expected-outputs*

--- a/src/Crypto/vec-repr.lisp
+++ b/src/Crypto/vec-repr.lisp
@@ -320,22 +320,21 @@ THE SOFTWARE.
 (defmethod base58 ((x base58))
   x)
 
-(defmethod base58 (x)
-  (cond
-    ((typep x 'vector)
-     (let* ((length (length x))
-            (int (int x))
-            (npad
-              ;; count the leading 0 bytes to pad:
-              (loop for i from 0 below length
-                    while (zerop (aref x i))
-                    count t)))
-       (make-instance
-        'base58
-        :str (integer-to-base58-with-pad int npad))))
-    (t (base58 x))))
+(defmethod base58 ((x vector))
+  (let* ((length (length x))
+         (int (int x))
+         (npad
+           ;; count the leading 0 bytes to pad:
+           (loop for i from 0 below length
+                 while (zerop (aref x i))
+                 count t)))
+    (make-instance
+     'base58
+     :str (integer-to-base58-with-pad int npad))))
 
 (defun integer-to-base58-with-pad (x npad)
+  "Return a string representation of integer X preceded by NPAD Base58
+   encodings of 0 as leading zero 'padding'."
   (let ((cs nil))
     (um:nlet-tail iter ((v x))
                   (when (plusp v)
@@ -347,6 +346,9 @@ THE SOFTWARE.
             repeat npad
             do (push char-for-0 cs)))
     (coerce cs 'string)))
+
+(defmethod base58 (x)
+  (base58 (int x)))
 
 ;; -------------------------------------------------------------
 ;; Vector Conversions


### PR DESCRIPTION
bitcoin-style base58-check p2pkh addresses

- vec-repr:base58 method now left-pads with encoded 0's in vector case
- added base58 encoding unit tests (lifted from bitcoin's)
  test with: (asdf:test-system :crypto-pairings/t)
  notice: Base58-test
- added new hashes: hash/ripemd/160 and has/sha2/256
- added new module address.lisp which exports public-key-to-address
- created new unit tests file address-tests.lisp
  test with (asdf:test-system :cosi-bls-tests)
  notice: "Public Key to Key Hash as Address Test (Base58Check Encoding)"