### PR TITLE
Define defstub - used to still compiler re many unimplemented functions.

### DIFF
--- a/src/Crypto/ecc-B571.lisp
+++ b/src/Crypto/ecc-B571.lisp
@@ -195,6 +195,9 @@ THE SOFTWARE.
       :alpha 1))
     ))
 
+
+(defstub c-ecc571-add)
+
 (defun ecc-double (pt)
   (optima:match pt
     ((ecc-infinite-)  pt)
@@ -273,6 +276,10 @@ THE SOFTWARE.
                   (lambda (pt)
                     (ecc-projective pt :alpha alpha)) ))
  
+
+
+(defstub c-ecc571-mul)
+
 (defun ecc-affine-mul (pt n)
   ;; left-to-right algorithm
   ;; for affine coordinates

--- a/src/Crypto/gf-571.lisp
+++ b/src/Crypto/gf-571.lisp
@@ -324,6 +324,10 @@ THE SOFTWARE.
                 (setf ans (logxor ans a)))) )
         ))
 
+
+(defstub c-gf571-mul)
+(defstub c-gf128-mul)
+
 (defun bin-gf* (a b)
   (cond
    ((or (zerop a)
@@ -425,6 +429,9 @@ THE SOFTWARE.
     g1))
 
   
+(defstub c-gf128-inv)
+(defstub c-gf571-inv)
+
 (defun gfinv (x)
   (case x
     (0  (error "Division by zero"))
@@ -458,6 +465,9 @@ THE SOFTWARE.
                   ans (gf* ans x)))
       ans)))
 |#
+
+(defstub c-gf128-div)
+(defstub c-gf571-div)
 
 (defun bin-gf/ (a b)
   (case b

--- a/src/Crypto/kdf.lisp
+++ b/src/Crypto/kdf.lisp
@@ -35,6 +35,8 @@ THE SOFTWARE.
   arr)
 
 
+(defstub c-kdf)
+
 (defun apply-c-kdf (nbits keys)
   (apply 'c-kdf nbits keys))
 

--- a/src/Crypto/utilities.lisp
+++ b/src/Crypto/utilities.lisp
@@ -27,25 +27,100 @@ THE SOFTWARE.
 
 (in-package :ecc-crypto-b571)
 
+
+
+;;;; Stubs for Unimplemented Functions
+
+;;; DEFSTUB: define a stub function named FUNCTION-NAME and set property
+;;; STUB-FUNCTION-P true on FUNCTION-NAME. The property setting is done at both
+;;; macro-evaluation and macro-expansion times, allowing its value to be used
+;;; both at compile and load times.
+
+;;; There are a set of functions that, for purposes of code clarity, need to
+;;; exist in regularly compiled code, but which shall, for the forseeable
+;;; future, never actually be called and therefore need not be defined.  We are
+;;; free, however, to define them as "stub" functions. A `stub function' should
+;;; never be called. If it is called at runtime, its behavior is undefined in
+;;; production. (It's OK for it to behave the same as in development, but that
+;;; is not required and should not be relied upon.)  In development, it's highly
+;;; desireable that calling a stub function should result in a runtime error
+;;; being signaled.
+
+;;; The main purpose and benefit of using defstub is to prevent the compiler
+;;; from complaining about unimplemented functions every single compile, when
+;;; you have no intention of ever fixing the situation in the present
+;;; development period.
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defmacro stub-function-p (function-name)
+  "Accessor on FUNCTION-NAME (getable, setf'able). Value either true, if
+FUNCTION-NAME is a symbol that is the name of a stub function, or false (nil)
+for any other symbol."
+  `(get ,function-name 'stub-function-p))
+)
+  
+
+(defmacro defstub (function-name)
+  (setf (stub-function-p function-name) t) ; set both at compile and load time
+  `(progn
+     (setf (stub-function-p ',function-name) t)
+     (defun ,function-name (&rest args)
+       (declare (ignore args))
+       (error "~s, a stub function, called at run time, but it should not be."
+              ',function-name))
+     ',function-name))
+
+
+
+
+
 ;; -----------------------------------------------------------------------------
-;;
+;; with-fast-impl (macro)
+
+(defmacro error-running-fast-impl-function? (fast-name)
+  "Accessor on a fast-impl-function name (getable, setf'able). Value can either
+be nil (initially) the Lisp error condition object from a first error condition
+from calling the function."
+  `(get ',fast-name 'error-running-fast-impl-function))
 
 (defun do-with-fast-impl (fast-name fast-fn slow-fn)
-  (or (and (fboundp fast-name)
+  (or (and (null (error-running-fast-impl-function? fast-name))
            (handler-case
                (funcall fast-fn)
-             (error ()
-               (fmakunbound fast-name)
+             (error (error-condition)
+               (progn
+                 ;; Throw a bone to a developer tracking down the error: log to
+                 ;; error output, and store error condition in a property on the
+                 ;; function name symbol.
+                 (format *error-output*
+                         "!!! *** Taking function ~S out. *** !!!~%" 
+                         fast-name)
+                 (format *error-output*
+                         "!!! ***   Error condition = ~A *** !!!~%" 
+                         error-condition)
+                 (format *error-output*
+                         "!!! ***   Error condition type = ~S *** !!!~%"
+                         (type-of error-condition)))
+
+               ;; Consider enabling this, maybe just in development mode:
+               ;; (cerror "Continue" "Error on fast-impl call of ~S" fast-name)
+
+               (setf (error-running-fast-impl-function? fast-name)
+                     error-condition)
                nil)))
       (funcall slow-fn)))
 
 (defmacro with-fast-impl (fast-form slow-form)
   (let ((fast-name (car fast-form)))
-    `(do-with-fast-impl ',fast-name
-                        (lambda ()
-                          ,fast-form)
-                        (lambda ()
-                          ,slow-form)) ))
+    (if (stub-function-p fast-name)
+        ;; If at expansion time we already know FAST-NAME names a stub function,
+        ;; do not expand a call to it: simply emit SLOW-FORM straight inline.
+        slow-form
+        `(do-with-fast-impl ',fast-name
+           (lambda ()
+             ,fast-form)
+           (lambda ()
+             ,slow-form)) )))
 
 ;; -----------------------------------------------------------------------------
 ;; junk PRNG - don't use this for cryptographic strength
@@ -419,6 +494,9 @@ THE SOFTWARE.
                 x             (ash x -8)))
     ans))
 
+
+(defstub sha2_file)
+
 #+:LISPWORKS
 (defun fast-sha2-file (fname)
   (fli:with-dynamic-foreign-objects ()
@@ -432,11 +510,15 @@ THE SOFTWARE.
                   (fli:dereference carr :index ix)))
       ans)))
   
+
 (defun sha2-file (fname)
   (with-fast-impl
    (fast-sha2-file fname)
    (let ((dig (ironclad:make-digest :sha256)))
      (ironclad:digest-file dig fname))))
+
+
+(defstub shad2_file)
 
 #+:LISPWORKS
 (defun fast-shad2-file (fname)
@@ -639,6 +721,9 @@ THE SOFTWARE.
 (defmethod ecc-projective-pt-p (pt)
   nil)
   
+
+(defstub gf-random-k*)
+
 (defun make-ecc-projective-pt (&key x y (z 1) alpha)
   (let* ((alpha   (or alpha
                       (gf-random-k*)))


### PR DESCRIPTION
This commit is primarily intended to eliminate pesky warnings.

For each function X in the crypto library that was not defined that we
got complaints about being called but not defined, there's now a
(defstub X) form.  This makes sure it's defined, although calling it
would not do anything really useful.  It also makes it known that the
function is a stub by adding a a property to the function name. That
property gets used by the little WITH-FAST-IMPL facility to avoid
generating a call to it.  I also cleaned up the error handling in
WITH-FAST-IMPL: previously, it would silently trap any error, and then
call makeunbound.  That's not a very clean way to handle it. First, it
should at least print the error, and help keep track of it.  Second,
it should not use makunbound. Instead, it now puts a flag property on
the function name and uses that as the gate to decide whether to call
the "fast" function.

NB: the speed of checking fboundp vs. property checks should be about
the same or noise level difference in most Lisps.  However, I suspect
either check might be adding significant overhad to the raw "fast"
call; review at a later date when we do optimization.