### PR TITLE
Fix warning re *current-node*, move cosi-netw-xlat after cosi-handlers

### DIFF
--- a/src/Cosi-BLS/cosi-bls.asd
+++ b/src/Cosi-BLS/cosi-bls.asd
@@ -50,10 +50,10 @@ THE SOFTWARE.
                                      (:file "block")
                                      (:file "cosi-keying")
 				     (:file "cosi-construction")
-                                     (:file "cosi-netw-xlat")
                                      (:file "range-proofs")
                                      (:file "transaction")
-                                     (:file "cosi-handlers")))))
+                                     (:file "cosi-handlers")
+                                     (:file "cosi-netw-xlat")))))
 
 
 


### PR DESCRIPTION
Moved module that used *current-node* to later in load order after its defvar is loaded.