### PR TITLE
Fixes for compilation under SBCL

### DIFF
--- a/src/Actors/actors.asd
+++ b/src/Actors/actors.asd
@@ -29,8 +29,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   :author      "D.McClain <dbm@refined-audiometrics.com>"
   :license     "Copyright (c) 2017 by Refined Audiometrics Laboratory, LLC. MIT License terms apply."
   :components  ((:file "packages")
-                #+:ALLEGRO (:file "allegro-timer")
-                #+:CLOZURE (:file "clozure-timer")
+                #-:lispworks
+                (:file "ansi-timer")
                 (:file "actors")
                 ;; (:file "actors-mb")
                 (:file "actors-machines")

--- a/src/Actors/ansi-timer.lisp
+++ b/src/Actors/ansi-timer.lisp
@@ -1,0 +1,103 @@
+(in-package :ansi-timer)
+
+(defvar *timeout-queue*  (priq:make-lifo))
+(defvar *cancel-queue*   (priq:make-lifo))
+(defvar *cycle-bits*     0.0d0)
+(defvar *last-check*     0)
+(defvar *timeout-tree*   (maps:empty))
+
+(defclass timer ()
+  ((period   :accessor timer-period
+             :initarg  :period
+             :initform nil
+             :documentation "True if timer should repeat periodically.")
+   (t0       :accessor timer-t0
+             :initarg  :t0
+             :initform 0
+             :documentation "Absolute universal-time when timer is set to expire.")
+   (fn       :accessor timer-fn
+             :initarg  :fn
+             :initform (constantly nil))
+   (args     :accessor timer-args
+             :initarg  :args
+             :initform nil)
+   ))
+
+(defun make-timer (fn &rest args)
+  (make-instance 'timer
+                 :fn   fn
+                 :args args))
+
+(defmethod schedule-timer ((timer timer) t0 &optional repeat)
+  (setf (timer-t0 timer) t0
+        (timer-period timer) repeat)
+  (priq:addq *timeout-queue* timer))
+
+(defmethod schedule-timer-relative ((timer timer) trel &optional repeat)
+  (let ((t0 (+ trel (get-universal-time))))
+    (setf (timer-t0 timer)     t0
+          (timer-period timer) repeat)
+    (priq:addq *timeout-queue* timer)))
+
+(defmethod unschedule-timer ((timer timer))
+  (priq:addq *cancel-queue* timer))
+
+
+(defun #1=check-timeouts ()
+  ;; read new requests
+  (loop for timer = (priq:popq *timeout-queue*)
+        while timer
+        do
+        (let* ((t0     (timer-t0 timer))
+               (timers (maps:find t0 *timeout-tree*))
+               (new    (cons timer (delete timer timers))))
+          (setf *timeout-tree* (maps:add t0 new *timeout-tree*))))
+  ;; process cancellations
+  (loop for timer = (priq:popq *cancel-queue*)
+        while timer
+        do
+        (let* ((t0     (timer-t0 timer))
+               (timers (maps:find t0 *timeout-tree*)))
+          (when timers
+            (let ((rem (delete timer timers)))
+              (setf *timeout-tree* (if rem
+                                       (maps:add t0 rem *timeout-tree*)
+                                     (maps:remove t0 *timeout-tree*)))))
+          ))
+  ;; check our current time
+  (let ((now (get-universal-time)))
+    (if (= now *last-check*)
+        (incf now (incf *cycle-bits* 0.1d0))
+      (setf *cycle-bits* 0.0d0
+            *last-check* now))
+    ;; fire off expired timers
+    (maps:iter (lambda (t0 timer-list)
+                 (when (> t0 now)
+                   (return-from #1#))
+                 (setf *timeout-tree* (maps:remove t0 *timeout-tree*))
+                 (dolist (timer timer-list)
+                   (let ((per (timer-period timer)))
+                     (when per
+                       (schedule-timer-relative timer per per)))
+                   (apply (timer-fn timer) (timer-args timer))
+                   #|
+                   (multiple-value-bind (ans err)
+                       (ignore-errors
+                         (apply (timer-fn timer) (timer-args timer)))
+                     (declare (ignore ans))
+                     (when err
+                       (unschedule-timer timer)))
+                   |#
+                   ))
+               *timeout-tree*)))
+      
+(defun make-master-timer ()
+  (mpcompat:process-run-function "Master Timer"
+    '()
+    (lambda ()
+      (loop
+       (sleep 0.1)
+       (check-timeouts)))))
+
+(defvar *master-timer* (make-master-timer))
+

--- a/src/Actors/packages.lisp
+++ b/src/Actors/packages.lisp
@@ -29,29 +29,15 @@ THE SOFTWARE.
 
 (in-package :CL-USER)
 
-#+:ALLEGRO
-(defpackage :allegro-timer
-  (:nicknames :atimer)
+#-lispworks
+(defpackage :ansi-timer
   (:use :common-lisp)
   (:export
    :timer
    :make-timer
    :schedule-timer
    :schedule-timer-relative
-   :unschedule-timer
-   ))
-
-#+:CLOZURE
-(defpackage :clozure-timer
-  (:nicknames :ctimer)
-  (:use :common-lisp)
-  (:export
-   :timer
-   :make-timer
-   :schedule-timer
-   :schedule-timer-relative
-   :unschedule-timer
-   ))
+   :unschedule-timer))
 
 (defpackage #:actors
   (:use #:common-lisp)
@@ -101,13 +87,8 @@ THE SOFTWARE.
    :make-timer
    :schedule-timer-relative
    :unschedule-timer)
-  #+:ALLEGRO
-  (:import-from :atimer
-   :make-timer
-   :schedule-timer-relative
-   :unschedule-timer)
-  #+:CLOZURE
-  (:import-from :ctimer
+  #-:lispworks
+  (:import-from :ansi-timer
    :make-timer
    :schedule-timer-relative
    :unschedule-timer)

--- a/src/Cosi-BLS/cosi-bls.asd
+++ b/src/Cosi-BLS/cosi-bls.asd
@@ -35,6 +35,7 @@ THE SOFTWARE.
                lisp-object-encoder
                useful-macros
                usocket
+               trivial-garbage
                ads-clos)
   :in-order-to ((test-op (test-op "cosi-bls-tests")))
   :components ((:module package

--- a/src/Cosi-BLS/cosi-netw-xlat.lisp
+++ b/src/Cosi-BLS/cosi-netw-xlat.lisp
@@ -33,13 +33,7 @@ THE SOFTWARE.
 
 (defparameter *aid-tbl*
   ;; assoc between Actors and AID's
-  #+:LISPWORKS (make-hash-table
-                :weak-kind :value)
-  #+:ALLEGRO   (make-hash-table
-                :values :weak)
-  #+:CLOZURE   (make-hash-table
-                :weak :value)
-  )
+  (trivial-garbage:make-weak-hash-table :weakness :value))
 
 (um:defmonitor
     ((associate-aid-with-actor (aid actor)
@@ -391,6 +385,3 @@ THE SOFTWARE.
       (internal-udp-cosi-client-send-request 'comm:close-async-io-state
                                              ip port packet)
       )))
-
-
-  

--- a/src/Crypto/crypto-environ.lisp
+++ b/src/Crypto/crypto-environ.lisp
@@ -34,10 +34,13 @@ THE SOFTWARE.
   pubkey-file)
 
 (defun make-crypto-environ ()
-  (let* ((home   (probe-file #+:MACOSX "~/"
-                             ;; #+:WIN32 (lw:environment-variable "USERPROFILE")
-                             #+:WIN32 (sys:get-user-profile-directory)))
-         (shared #+:MACOSX (or (probe-file "~/Dropbox/Team Share/")
+  (let* ((home   (probe-file
+                  #-(or :macosx :win32) "~/"
+                  #+:MACOSX "~/" ;; #+:WIN32 (lw:environment-variable "USERPROFILE")
+                  #+:WIN32 (sys:get-user-profile-directory)))
+         (shared
+                 #-(or :macosx :win32) "/var/tmp/" ;; FIXME
+                 #+:MACOSX (or (probe-file "~/Dropbox/Team Share/")
                                (probe-file "~/Documents/Dropbox/Team Share/"))
                  #+:WIN32  (probe-file (merge-pathnames "Dropbox/Team Share/" home)))
          (pwd    (merge-pathnames "_acudora-ecc-passwds" home))

--- a/src/Crypto/modular-arith.lisp
+++ b/src/Crypto/modular-arith.lisp
@@ -210,10 +210,12 @@ THE SOFTWARE.
   (declare (integer arg))
   (let* ((blinder (get-blinder)))
     (declare (integer blinder))
-    (dolist (opnd args arg)
+    (dolist (opnd args)
       (declare (integer opnd))
-      (setf arg (mmod (* arg (+ opnd blinder)))))
-    ))
+      (setf arg (mmod (* arg (+ opnd blinder))))))
+  arg)
+    
+
 
 ;; ------------------------------------------------------------
 
@@ -260,8 +262,8 @@ THE SOFTWARE.
 
 (defun m/ (arg &rest args)
   (declare (integer arg))
-  (dolist (opnd args
-                (if args arg (minv arg)))
+  (dolist (opnd args)
     (declare (integer opnd))
-    (setf arg (m* arg (minv opnd)))))
+    (setf arg (m* arg (minv opnd))))
+  (if args arg (minv arg)))
 

--- a/src/Crypto/vec-repr.lisp
+++ b/src/Crypto/vec-repr.lisp
@@ -92,9 +92,9 @@ THE SOFTWARE.
 ;; ----------------------------------------------------------
 ;; from https://bitcointalk.org/index.php?topic=1026.0
 
-(defconstant +alphabet-58+
+(um:defconstant+ +alphabet-58+
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
-(defconstant +len-58+
+(um:defconstant+ +len-58+
   (length +alphabet-58+)) ;; should be 58
 
 (defun make-inverse-alphabet (alphabet)
@@ -111,7 +111,7 @@ THE SOFTWARE.
 
 ;; ----------------------------------------------------------
 
-(defconstant +alphabet-64+
+(um:defconstant+ +alphabet-64+
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
 
 (defvar +inv-alphabet-64+

--- a/src/mpcompat/mp-compat-sbcl.lisp
+++ b/src/mpcompat/mp-compat-sbcl.lisp
@@ -70,8 +70,7 @@ THE SOFTWARE.
 
 (defun process-run-function (name flags proc &rest args)
   "Spawn a new Lisp thread and run the indicated function with inital args."
-  (declare (ignore flags)
-           (type function proc))
+  (declare (ignore flags))
   (sb-thread:make-thread (lambda ()
 			   (apply proc args))
 			 :name name))
@@ -117,9 +116,9 @@ THE SOFTWARE.
 	      (handler-case
 		  (sb-ext:with-timeout timeout
 		    (sb-sys:allow-with-interrupts
-		      (sb-thread:get-mutex lock nil t)) ;; Deprecated 
+                      (sb-thread:grab-mutex lock :waitp t))
 		    (go have-lock))
-		(timeout (cx)
+		(sb-ext:timeout (cx)
 		  (declare (ignore cx))
 		  (go beyond))))
 	    have-lock


### PR DESCRIPTION
With these changes, `emotiq/sim` will compile under SBCL.  

The blockchain simulation doesn't seem to complete correctly, but at least things compile