### PR TITLE
sdle-store: explicitly remove unneeded actors system dependency

### DIFF
--- a/src/Crypto/crypto-pairings.asd
+++ b/src/Crypto/crypto-pairings.asd
@@ -41,8 +41,10 @@ THE SOFTWARE.
   (prepare-op
    :before (o c)
    (let ((wildcard-for-libraries
-          (asdf:system-relative-pathname
-           :emotiq "../var/local/lib/libLispPBCIntf.*")))
+          (make-pathname :defaults 
+                         (asdf:system-relative-pathname
+                          :emotiq "../var/local/lib/libLispPBCIntf")
+                         :type :wild)))
      (unless (directory wildcard-for-libraries)
        (format *standard-output*
                "~&Failed to find libraries matching~&~t~a~&~

--- a/src/sdle-store/sdle-store.asd
+++ b/src/sdle-store/sdle-store.asd
@@ -44,13 +44,12 @@ CLISP, ECL and AllegroCL are supported.")
   :name "SDLE-STORE"
   :author "Sean Ross <sross@common-lisp.net>; hacked by DM/SD 09/08"
   :maintainer "Sean Ross <sross@common-lisp.net>"
-  :version "0.8.5"
+  :version "0.9.0"
   :description "Serialization package"
   :long-description "Portable CL Package to serialize data"
   :licence "MIT"
   :in-order-to ((test-op (test-op "sdle-store/tests")))
-  :depends-on (useful-macros
-               actors) ;; Actors contains the improved defintion of UM.LAZY
+  :depends-on (useful-macros)
   :serial t
   :components ((:file "package")
                (:file "utils")
@@ -63,7 +62,6 @@ CLISP, ECL and AllegroCL are supported.")
                (:file "default-backend")
                (:non-required-file "custom")))
 
-
 (defmethod perform :after ((o load-op) (c (eql (find-system :sdle-store))))
   (funcall (find-symbol "SETUP-SPECIAL-FLOATS" :sdle-store))
   (provide 'sdle-store))
@@ -73,7 +71,3 @@ CLISP, ECL and AllegroCL are supported.")
   :components ((:module tests
                         :pathname "./"
                         :components ((:file "tests")))))
-
-
-
-;; EOF


### PR DESCRIPTION
Finish what we started:  unless we remove the ASDF dependency of `sdle-store` on `actors`, loading `core-crypto` will still kick off the actors `load-toplevel` initialization routine.  

One can examine what is loaded via ASDF with code like:
```
(in-package :cl-user)

(defvar cl-user::*loaded-asdf-systems* nil)

(defmethod asdf:perform :before ((operation asdf::load-op) (system asdf:system))
  (push system cl-user::*loaded-asdf-systems*))
```