### PR TITLE
Dbm 0604a

### DIFF
--- a/src/Actors/actors.asd
+++ b/src/Actors/actors.asd
@@ -35,7 +35,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 ;; (:file "actors-mb")
                 (:file "actors-machines")
                 (:file "actors-startup")
-                #+(or) (:file "futures")
+                #+(AND :COM.RAL :LISPWORKS) (:file "futures")
                 #+(AND :COM.RAL :LISPWORKS) (:file "linda-tuples")
                 #|
                 (:file "actors-macros")

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -860,7 +860,7 @@ check that each TXIN and TXOUT is mathematically sound."
 (=defun gossip-signing (my-node consensus-stage blk blk-hash  seq-id timeout)
   (let ((*current-node* my-node))
     (cond ((and *use-gossip*
-                (int= (node-pkey my-node) *leader*))
+                (vec= (node-pkey my-node) *leader*))
            ;; we are leader node, so fire off gossip spray and await answers
            (let ((bft-thrsh (bft-threshold blk))
                  (start     nil)
@@ -931,7 +931,7 @@ check that each TXIN and TXOUT is mathematically sound."
          (bft-threshold blk))))
 
 (defun check-block-transactions-hash (blk)
-  (int= (block-merkle-root-hash blk) ;; check transaction hash against header
+  (vec= (block-merkle-root-hash blk) ;; check transaction hash against header
         (compute-merkle-root-hash
          (block-transactions blk))))
 
@@ -973,13 +973,13 @@ check that each TXIN and TXOUT is mathematically sound."
     (:prepare
      ;; blk is a pending block
      ;; returns nil if invalid - should not sign
-     (and (int= *leader* (block-leader-pkey blk))
+     (and (vec= *leader* (block-leader-pkey blk))
           (check-block-transactions-hash blk)
           (let ((prevblk (first *blockchain*)))
             (or (null prevblk)
                 (and (> (block-timestamp blk) (block-timestamp prevblk))
-                     (int= (block-prev-block-hash blk) (hash-block prevblk)))))
-          (or (int= (node-pkey node) *leader*)
+                     (vec= (block-prev-block-hash blk) (hash-block prevblk)))))
+          (or (vec= (node-pkey node) *leader*)
               (check-block-transactions blk))
           ))
 
@@ -988,7 +988,7 @@ check that each TXIN and TXOUT is mathematically sound."
      ;; validity and then sign to indicate we have seen and committed
      ;; block to blockchain. Return non-nil to indicate willingness to sign.
      (unwind-protect
-         (when (and (int= *leader* (block-leader-pkey blk))
+         (when (and (vec= *leader* (block-leader-pkey blk))
                     (check-block-multisignature blk))
            (push blk *blockchain*)
            (setf (gethash (cosi/proofs:hash-block blk) *blockchain-tbl*) blk)
@@ -1022,7 +1022,7 @@ check that each TXIN and TXOUT is mathematically sound."
                    (ac:pr (format nil "Block validated ~A" (short-id node)))
                    (list (pbc:sign-hash blk-hash (node-skey node))
                          (ash 1 (position (node-pkey node) (block-witnesses blk)
-                                          :test 'int=))))
+                                          :test 'vec=))))
                (progn
                  (ac:pr (format nil "Block not validated ~A" (short-id node)))
                  (list nil 0)))))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -860,7 +860,7 @@ check that each TXIN and TXOUT is mathematically sound."
 (=defun gossip-signing (my-node consensus-stage blk blk-hash  seq-id timeout)
   (let ((*current-node* my-node))
     (cond ((and *use-gossip*
-                (vec= (node-pkey my-node) *leader*))
+                (int= (node-pkey my-node) *leader*))
            ;; we are leader node, so fire off gossip spray and await answers
            (let ((bft-thrsh (bft-threshold blk))
                  (start     nil)
@@ -931,9 +931,9 @@ check that each TXIN and TXOUT is mathematically sound."
          (bft-threshold blk))))
 
 (defun check-block-transactions-hash (blk)
-  (vec= (block-merkle-root-hash blk) ;; check transaction hash against header
-        (compute-merkle-root-hash
-         (block-transactions blk))))
+  (hash= (block-merkle-root-hash blk) ;; check transaction hash against header
+         (compute-merkle-root-hash
+          (block-transactions blk))))
 
 (defmethod add-pkeys ((pkey1 null) pkey2)
   pkey2)
@@ -973,13 +973,13 @@ check that each TXIN and TXOUT is mathematically sound."
     (:prepare
      ;; blk is a pending block
      ;; returns nil if invalid - should not sign
-     (and (vec= *leader* (block-leader-pkey blk))
+     (and (int= *leader* (block-leader-pkey blk))
           (check-block-transactions-hash blk)
           (let ((prevblk (first *blockchain*)))
             (or (null prevblk)
                 (and (> (block-timestamp blk) (block-timestamp prevblk))
-                     (vec= (block-prev-block-hash blk) (hash-block prevblk)))))
-          (or (vec= (node-pkey node) *leader*)
+                     (hash= (block-prev-block-hash blk) (hash-block prevblk)))))
+          (or (int= (node-pkey node) *leader*)
               (check-block-transactions blk))
           ))
 
@@ -988,7 +988,7 @@ check that each TXIN and TXOUT is mathematically sound."
      ;; validity and then sign to indicate we have seen and committed
      ;; block to blockchain. Return non-nil to indicate willingness to sign.
      (unwind-protect
-         (when (and (vec= *leader* (block-leader-pkey blk))
+         (when (and (int= *leader* (block-leader-pkey blk))
                     (check-block-multisignature blk))
            (push blk *blockchain*)
            (setf (gethash (cosi/proofs:hash-block blk) *blockchain-tbl*) blk)
@@ -1022,7 +1022,7 @@ check that each TXIN and TXOUT is mathematically sound."
                    (ac:pr (format nil "Block validated ~A" (short-id node)))
                    (list (pbc:sign-hash blk-hash (node-skey node))
                          (ash 1 (position (node-pkey node) (block-witnesses blk)
-                                          :test 'vec=))))
+                                          :test 'int=))))
                (progn
                  (ac:pr (format nil "Block not validated ~A" (short-id node)))
                  (list nil 0)))))

--- a/src/Cosi-BLS/range-proofs-pbc.lisp
+++ b/src/Cosi-BLS/range-proofs-pbc.lisp
@@ -364,7 +364,8 @@ THE SOFTWARE.
            ))))
 
 (defvar *chk-bp-basis*
-  #x817364794f007ce83fa54d376fe225c8425f277bea914ac6d69a5f8c27dbc528)
+  ;; = (hex-str (hash/256 *bp-basis*))
+  "817364794f007ce83fa54d376fe225c8425f277bea914ac6d69a5f8c27dbc528")
 
 (assert (hash-check *bp-basis* *chk-bp-basis*))
 

--- a/src/Cosi-BLS/range-proofs.lisp
+++ b/src/Cosi-BLS/range-proofs.lisp
@@ -624,8 +624,8 @@ THE SOFTWARE.
                                                  :Z 9507787602201723372052147491550764275248437713628282754480216598228666537920807278018546459799443464094514589685112))))
 
 (defvar *chk-bp-basis*
-  ;; (HASH/256 *bp-basis*)
-  #xf517bb89109c3b7470a97f0c4b6fc1647e515f9426fbb5aa6f0786065e29c99d)
+  ;; = (hex-str (HASH/256 *bp-basis*))
+  "f517bb89109c3b7470a97f0c4b6fc1647e515f9426fbb5aa6f0786065e29c99d")
 |#
 
 #| ;; for 128 bit security |#
@@ -1038,8 +1038,8 @@ THE SOFTWARE.
    ))
 
 (defvar *chk-bp-basis*
-  ;; (HASH/256 *bp-basis*)
-  #xdbb5d20d21439523959d090d0477ca7f51e5771f031afa0221f8c1faa860fca7)
+  ;; = (hex-str (HASH/256 *bp-basis*))
+  "dbb5d20d21439523959d090d0477ca7f51e5771f031afa0221f8c1faa860fca7")
 #| |#
 
 ;; --------------------------------------------------------------------------------

--- a/src/Cosi-BLS/reconstruct.lisp
+++ b/src/Cosi-BLS/reconstruct.lisp
@@ -112,7 +112,7 @@
           (um:nlet-tail iter ((blk  (get-most-recent-block)))
             (when blk
               ;; check that blkid = Hash(blk)
-              (assert (int= (block-hash blk)
+              (assert (vec= (block-hash blk)
                             (hash-block blk)))
               (acc blk)
               (iter (get-block (block-prev blk))))))

--- a/src/Cosi-BLS/reconstruct.lisp
+++ b/src/Cosi-BLS/reconstruct.lisp
@@ -58,8 +58,8 @@
   (um:nlet-tail iter ((blk  (get-most-recent-block)))
     (when blk
       ;; check that blkid = Hash(blk)
-      (assert (= (int (block-hash blk))
-                 (int (hash-block blk))))
+      (assert (hash= (block-hash blk)
+                     (hash-block blk)))
       (push (make-chain-block
              :block blk)
             *blockchain*)

--- a/src/Cosi-BLS/transaction.lisp
+++ b/src/Cosi-BLS/transaction.lisp
@@ -224,7 +224,7 @@ Typically used for stakes. Public key is G2, Secret key is 1."
                  (trans-gamadj trn)))
 
 (defmethod =hash-trn ((trn transaction) hash)
-  (int= hash (hash-trn trn)))
+  (vec= hash (hash-trn trn)))
 
 (defun do-make-transaction (txins gam-txins txouts txout-secrets fee)
   "TXINS is a list of TXIN structs, TXOUTS is a list of TXOUT structs,
@@ -374,7 +374,7 @@ during TXIN formation will be properly disposed of."
 (defmethod find-txin-for-pkey-hash (pkey (trn transaction))
   (find pkey (trans-txins trn)
         :key 'txin-pkey
-        :test 'int=))
+        :test 'vec=))
 
 
 (defmethod decrypt-txout-info ((txout cloaked-txout) skey)
@@ -383,7 +383,7 @@ during TXIN formation will be properly disposed of."
 (defmethod find-txout-for-pkey-hash (pkey-hash (trn transaction))
   (find pkey-hash (trans-txouts trn)
         :key  'txout-hashpkey
-        :test 'int=))
+        :test 'vec=))
 
 ;; ------------------------------------------------------------------
 #|

--- a/src/Cosi-BLS/transaction.lisp
+++ b/src/Cosi-BLS/transaction.lisp
@@ -224,7 +224,7 @@ Typically used for stakes. Public key is G2, Secret key is 1."
                  (trans-gamadj trn)))
 
 (defmethod =hash-trn ((trn transaction) hash)
-  (hash= hash (hash-trn trn)))
+  (hash:hash= hash (hash-trn trn)))
 
 (defun do-make-transaction (txins gam-txins txouts txout-secrets fee)
   "TXINS is a list of TXIN structs, TXOUTS is a list of TXOUT structs,
@@ -311,8 +311,8 @@ during TXIN formation will be properly disposed of."
 (defmethod validate-txin ((utx cloaked-txin) hash)
   (let* ((hl  (make-hashlock (txin-prf utx)
                              (txin-pkey utx))))
-    (and (hash= hl
-                (txin-hashlock utx))
+    (and (hash:hash= hl
+                     (txin-hashlock utx))
          (pbc:check-hash hash
                          (txin-sig utx)
                          (txin-pkey utx))
@@ -324,8 +324,8 @@ during TXIN formation will be properly disposed of."
          (hl   (make-hashlock (pedersen-commitment utx)
                               (txin-pkey utx))))
     (and (check-amt amt)
-         (hash= hl
-                (txin-hashlock utx))
+         (hash:hash= hl
+                     (txin-hashlock utx))
          (pbc:check-hash hash
                          (txin-sig utx)
                          (txin-pkey utx)))))
@@ -383,7 +383,7 @@ during TXIN formation will be properly disposed of."
 (defmethod find-txout-for-pkey-hash (pkey-hash (trn transaction))
   (find pkey-hash (trans-txouts trn)
         :key  'txout-hashpkey
-        :test 'hash=))
+        :test 'hash:hash=))
 
 ;; ------------------------------------------------------------------
 #|

--- a/src/Cosi-BLS/transaction.lisp
+++ b/src/Cosi-BLS/transaction.lisp
@@ -224,7 +224,7 @@ Typically used for stakes. Public key is G2, Secret key is 1."
                  (trans-gamadj trn)))
 
 (defmethod =hash-trn ((trn transaction) hash)
-  (vec= hash (hash-trn trn)))
+  (hash= hash (hash-trn trn)))
 
 (defun do-make-transaction (txins gam-txins txouts txout-secrets fee)
   "TXINS is a list of TXIN structs, TXOUTS is a list of TXOUT structs,
@@ -311,8 +311,8 @@ during TXIN formation will be properly disposed of."
 (defmethod validate-txin ((utx cloaked-txin) hash)
   (let* ((hl  (make-hashlock (txin-prf utx)
                              (txin-pkey utx))))
-    (and (= (int hl)
-            (int (txin-hashlock utx)))
+    (and (hash= hl
+                (txin-hashlock utx))
          (pbc:check-hash hash
                          (txin-sig utx)
                          (txin-pkey utx))
@@ -324,8 +324,8 @@ during TXIN formation will be properly disposed of."
          (hl   (make-hashlock (pedersen-commitment utx)
                               (txin-pkey utx))))
     (and (check-amt amt)
-         (= (int hl)
-            (int (txin-hashlock utx)))
+         (hash= hl
+                (txin-hashlock utx))
          (pbc:check-hash hash
                          (txin-sig utx)
                          (txin-pkey utx)))))
@@ -374,7 +374,7 @@ during TXIN formation will be properly disposed of."
 (defmethod find-txin-for-pkey-hash (pkey (trn transaction))
   (find pkey (trans-txins trn)
         :key 'txin-pkey
-        :test 'vec=))
+        :test 'int=))
 
 
 (defmethod decrypt-txout-info ((txout cloaked-txout) skey)
@@ -383,7 +383,7 @@ during TXIN formation will be properly disposed of."
 (defmethod find-txout-for-pkey-hash (pkey-hash (trn transaction))
   (find pkey-hash (trans-txouts trn)
         :key  'txout-hashpkey
-        :test 'vec=))
+        :test 'hash=))
 
 ;; ------------------------------------------------------------------
 #|

--- a/src/Crypto/ecc-package.lisp
+++ b/src/Crypto/ecc-package.lisp
@@ -92,6 +92,7 @@ THE SOFTWARE.
    :convert-int-to-vector
    :convert-vector-to-int
    :int=
+   :vec=
    ))
 
 (defpackage :hash

--- a/src/Crypto/ecc-package.lisp
+++ b/src/Crypto/ecc-package.lisp
@@ -86,6 +86,7 @@ THE SOFTWARE.
    :base64-str
    :hex
    :hex-str
+   :hex-of-str
    :int
    :levn
    :bevn
@@ -111,6 +112,7 @@ THE SOFTWARE.
    :get-hash-nbytes
    :hashable
    :hash-check
+   :hash=
    ))
 
 (defpackage :ecc-crypto-b571

--- a/src/Crypto/edwards.lisp
+++ b/src/Crypto/edwards.lisp
@@ -95,7 +95,8 @@ THE SOFTWARE.
    ))
 
 (defvar *chk-curve1174*
-  #x50c953d8d6f83ab18a8a475acc04567cf621ea543a576f20d70f1f1784a3c727)
+  ;; = (hex-str (hash/256 *curve1174))
+  "50c953d8d6f83ab18a8a475acc04567cf621ea543a576f20d70f1f1784a3c727")
 
 ;; ---------------------------
 
@@ -115,7 +116,8 @@ THE SOFTWARE.
    ))
 
 (defvar *chk-curve-E382*
-  #x58aa9ce913eb890d831f3ec0e59d0aaaf32304cc4240bfc6ff045599b8ac8419)
+  ;; = (hex-str (hash/256 *curve-E382*))
+  "58aa9ce913eb890d831f3ec0e59d0aaaf32304cc4240bfc6ff045599b8ac8419")
 
 ;; ---------------------------
 
@@ -135,7 +137,8 @@ THE SOFTWARE.
    ))
 
 (defvar *chk-curve41417*
-  #xa26c08cde33e9d353b0ec47090c1d6fdea32842d9e5b7130a026b09e02d10fd0)
+  ;; = (hex-str (hash/256 *curve41417*))
+  "a26c08cde33e9d353b0ec47090c1d6fdea32842d9e5b7130a026b09e02d10fd0")
 
 ;; ---------------------------
 
@@ -155,7 +158,8 @@ THE SOFTWARE.
    ))
 
 (defvar *chk-curve-E521*
-  #x689a5918f2d28f1d62965551d44c635a141b623ad672b464b21052b481a21420)
+  ;; = (hex-str (hash/256 *curve-E521*))
+  "689a5918f2d28f1d62965551d44c635a141b623ad672b464b21052b481a21420")
 
 ;; ------------------------------------------------------
 

--- a/src/Crypto/hash.lisp
+++ b/src/Crypto/hash.lisp
@@ -170,6 +170,10 @@ THE SOFTWARE.
       (subseq bytes 0 nb)))
    ))
 
-(defun hash-check (item expected)
-  (= expected (int (hash/256 item))))
+(defmethod hash-check (item (expected string))
+  (string-equal expected (hex-str (hash/256 item))))
+
+(defmethod hash= ((hash1 hash) (hash2 hash))
+  (vec= hash1 hash2))
+
 

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -423,7 +423,7 @@ Size of q^12 is 5388 bits.
 Was shooting for q ~ 2^448, but Lynn's library chokes on that. Works fine on 2^449.")
 
 (defparameter *chk-curve-fr449-params*
-  #xd7d23d0f93cf297e2f10da33cfc1425bd43b72089e6e8522807e97dc13243fef)
+  "d7d23d0f93cf297e2f10da33cfc1425bd43b72089e6e8522807e97dc13243fef")
 
 ;; ---------------------------------------------------------------------------------------
 ;; from modified genfparam 256
@@ -458,7 +458,7 @@ Barreto and Naehrig
 Size of q^12 is 3072 bits.")
 
 (defparameter *chk-curve-fr256-params*
-  #xb937a11b2d71b08fecddfdd2be170ed1dfab1bd8891d45914f071cc63cd28443)
+  "b937a11b2d71b08fecddfdd2be170ed1dfab1bd8891d45914f071cc63cd28443")
 
 ;; ---------------------------------------------------------------------------------------
 ;; from modified genfparam 255
@@ -625,7 +625,7 @@ alpha1 3001017353864017826546717979647202832842709824816594729108687826591920660
 3 out of 4 hash/256")
 
 (defparameter *chk-curve-fr256-params-old*
-  #xec9f36b197a11280f6cc4b47a8a3dc7b8663ccbb3975c3068c9069803673361d)
+  "ec9f36b197a11280f6cc4b47a8a3dc7b8663ccbb3975c3068c9069803673361d")
 
 ;; ---------------------------------------------------------------------------------------
 (defparameter *curve-default-ar160-params*
@@ -655,7 +655,7 @@ serves as a check on our implementation with his pbc-calc for
 comparison.")
 
 (defparameter *chk-curve-default-ar160-params*
-  #x16e0d04684238b1aae7e828c795fa3dcd1c3d9e12abee5d72cfacff944b1bf38)
+  "16e0d04684238b1aae7e828c795fa3dcd1c3d9e12abee5d72cfacff944b1bf38")
 
 ;; ---------------------------------------------------------------------------------------
 

--- a/src/Crypto/subkey-derivation.lisp
+++ b/src/Crypto/subkey-derivation.lisp
@@ -140,6 +140,6 @@ parent-chain and index for same parent keying."
       (ckd-secret-key (keying-triple-skey k) c 1)
     (multiple-value-bind (cpkey cchain2)
         (ckd-public-key (keying-triple-pkey k) c 1)
-      (assert (int= (public-of-secret cskey) cpkey))
-      (assert (int= cchain cchain2)))))
+      (assert (vec= (public-of-secret cskey) cpkey))
+      (assert (vec= cchain cchain2)))))
 |#

--- a/src/Crypto/vec-repr.lisp
+++ b/src/Crypto/vec-repr.lisp
@@ -153,7 +153,13 @@ THE SOFTWARE.
             (class-name (class-of obj))
             (ub8v-vec obj))))
 
+(defun hex-digit-char (c)
+  (or (char<= #\0 #\9)
+      (char<= #\a #\f)
+      (char<= #\A #\F)))
+
 (defun hex-of-str (str)
+  (assert (every 'hex-digit-char str))
   (make-instance 'hex
                  :str str))
 
@@ -591,7 +597,9 @@ THE SOFTWARE.
 
 (defun int= (a b)
   "Poor way to do equality testing on UB8V items. This method fails to
-account for vectors with leading null bytes."
+account for vectors with leading null bytes. Okay for comparing
+compressed ECC points - public keys, signatures. Not okay for hash
+comparisons."
   (= (int a) (int b)))
 
 (defun vec= (a b)

--- a/src/Crypto/vec-repr.lisp
+++ b/src/Crypto/vec-repr.lisp
@@ -590,6 +590,10 @@ THE SOFTWARE.
           )))
 
 (defun int= (a b)
-  "Easy way to do equality testing on UB8V items"
+  "Poor way to do equality testing on UB8V items. This method fails to
+account for vectors with leading null bytes."
   (= (int a) (int b)))
 
+(defun vec= (a b)
+  "Easy way to do equality testing on UB8V items"
+  (equalp (bev-vec a) (bev-vec b)))


### PR DESCRIPTION
Was using INT= to compare hashes, public keys, signatures, etc. Not really appropriate because conversion to INT ignores leading null bytes of vector quantities. Instead, we should use VEC= which first ensures that each operand is a BEV, and then compares byte by byte of the vectors.

The situation is more subtle than just described. ECC points (compressed form) can be legitimately compared with INT=. Hash values, which can easily have leading zero bytes should be compared with HASH=. Arbitrary raw vectors can be compared with VEC=. 

When hash values are used as Shamir-Fiat values, they can be compared with INT= (The object of Shamir-Fiat challenges is to compute some random challenge value, generally based on the hash of public information in the proof transcript.)

HASH= is a defmethod that expects two HASH class values. In our final public form of the blockchain, it is possible that these items will be stored as raw C vectors, in which case some type conversions will be needed before HASH= is used.