### PR TITLE
Added some verbosity to `test-harness` results

### DIFF
--- a/etc/test-harness.bash
+++ b/etc/test-harness.bash
@@ -32,7 +32,7 @@ systems=${systems:-":emotiq/blockchain
                     :crypto-pairings/t
                     :core-crypto"}
 
-echo Test harness invoked using implementation:
+echo Test harness invoked using implementation: ${lisp}
 echo $(${lisp} --eval '(format t "~&~a ~a~&" (lisp-implementation-type)(lisp-implementation-version))(uiop:quit 0)')
 
 for system in ${systems}; do
@@ -48,4 +48,3 @@ for system in ${systems}; do
     fi
     echo "<== ASDF:TEST-SYSTEM on ${system} succeeded."
 done
-                                      

--- a/etc/test-harness.lisp
+++ b/etc/test-harness.lisp
@@ -14,10 +14,10 @@
   (handler-case
       (if (asdf:test-system system)
           (progn
-            (format *standard-output* "~&Test passed for system: `~a`~&" system)
+            (format *standard-output* "~&Test-system succeeded for system: `~a`~&" system)
             (uiop:quit 0))
           (progn
-            (format *standard-output* "~&Test failed for system: `~a`~&" system)
+            (format *standard-output* "~&Test-system failed for system: `~a`~&" system)
             (uiop:quit -1)))
     (error (e)
       (format *standard-output*

--- a/etc/test-harness.lisp
+++ b/etc/test-harness.lisp
@@ -5,7 +5,7 @@
 (in-package :test-harness)
 
 (defun test-system (system)
-  (handler-case 
+  (handler-case
       (ql:quickload system)
     (error (e)
       (format *standard-output*
@@ -13,8 +13,12 @@
       (uiop:quit -1)))
   (handler-case
       (if (asdf:test-system system)
-          (uiop:quit 0)
-          (uiop:quit -1))
+          (progn
+            (format *standard-output* "~&Test passed for system: `~a`~&" system)
+            (uiop:quit 0))
+          (progn
+            (format *standard-output* "~&Test failed for system: `~a`~&" system)
+            (uiop:quit -1)))
     (error (e)
       (format *standard-output*
               "~&Testing system `~a` signalled error:~&~a~&" system e)


### PR DESCRIPTION
Just a handy report messages to see actual tests results as returned by `(asdf:test-system system)`