### PR TITLE
Dbm 0605b

### DIFF
--- a/src/Actors/actors-startup.lisp
+++ b/src/Actors/actors-startup.lisp
@@ -215,7 +215,8 @@ THE SOFTWARE.
   (declare (ignore ignored))
   (unless (directory-manager-p)
     (install-actor-directory)
-    (install-actor-printer)))
+    (install-actor-printer)
+    ))
 
 #-:lispworks
 (eval-when (:load-toplevel)

--- a/src/Actors/actors.lisp
+++ b/src/Actors/actors.lisp
@@ -524,7 +524,7 @@ THE SOFTWARE.
         (mp:mailbox-read mbox)
         (iter)))))
 
-#+(or :ALLEGRO :CLOZURE)
+#+(or :ALLEGRO :CLOZURE :SBCL)
 (let ((queue (list nil))
       (lock  (mpcompat:make-lock)))
 

--- a/src/Actors/actors.lisp
+++ b/src/Actors/actors.lisp
@@ -633,6 +633,24 @@ THE SOFTWARE.
   (max 4 (ccl:cpu-count))
   #-(or :CLOZURE (AND :LISPWORKS :MACOSX)) 4)
 
+(defun default-watchdog-function ()
+  (restart-case
+      (error "Actor Executives are stalled (blocked waiting or compute bound). ~&Last heartbeat was ~A sec ago."
+             age)
+    (:do-nothing-just-wait ()
+      :report "It's okay, just wait"
+      (start-watchdog-timer))
+    (:spawn-new-executive ()
+      :report "Spawn another Executive"
+      (incf *nbr-execs*)
+      (push-new-executive))
+    (:stop-actor-system ()
+      :report "Stop Actor system"
+      (kill-executives))
+    ))
+
+(defvar *watchdog-hook* 'default-watchdog-function)
+
 ;; ----------------------------------------------------------------
 ;; Ready Queue
 
@@ -727,22 +745,8 @@ THE SOFTWARE.
            (mpcompat:process-run-function
             "Handle Stalling Actors"
             '()
-            (lambda ()
-              (restart-case
-                  (error "Actor Executives are stalled (blocked waiting or compute bound). ~&Last heartbeat was ~A sec ago."
-                         age)
-                (:do-nothing-just-wait ()
-                  :report "It's okay, just wait"
-                  (start-watchdog-timer))
-                (:spawn-new-executive ()
-                  :report "Spawn another Executive"
-                  (incf *nbr-execs*)
-                  (push-new-executive))
-                (:stop-actor-system ()
-                  :report "Stop Actor system"
-                  (kill-executives))
-                ))
-            ))))
+            *watchdog-hook*)
+           )))
 
      (remove-from-pool (proc)
        (setf *executive-processes* (delete proc *executive-processes*)))

--- a/src/Actors/packages.lisp
+++ b/src/Actors/packages.lisp
@@ -94,7 +94,6 @@ THE SOFTWARE.
    :unschedule-timer)
   (:export
    #:install-actor-system
-   #:*nbr-execs*
    #:actor
    #:make-actor
    #:send
@@ -146,6 +145,11 @@ THE SOFTWARE.
 
    #:install-actor-system
 
+   #:default-watchdog-function
+   #:*watchdog-hook*
+   #:*maximum-age*
+   #:*nbr-execs*
+   #:*heartbeat-interval*
    ))
 
 (defpackage #:linda

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -423,6 +423,7 @@ Size of q^12 is 5388 bits.
 Was shooting for q ~ 2^448, but Lynn's library chokes on that. Works fine on 2^449.")
 
 (defparameter *chk-curve-fr449-params*
+  ;; = (hex-str (hash/256 *curve-fr449-params*))
   "d7d23d0f93cf297e2f10da33cfc1425bd43b72089e6e8522807e97dc13243fef")
 
 ;; ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Merge dev into dbm, change watchdog timer code to refer to user replaceable vector *WATCHDOG-HOOK*, which defaults to DEFAULT-WATCHDOG-FUNCTION.

This makes it easier to replace behavior as needed for business requirements.