### PR TITLE
Add string normalizer utility

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -7,7 +7,10 @@
   (:export #:octet #:octet-vector #:octet-vector-p
            #:make-octet-vector #:ovref
            #:octet-vector-to-hex-string #:hex-string-to-octet-vector
-           #:string-to-octet-vector)
+           #:string-to-octet-vector
+
+           #:normalize-to-base-string #:copy-as-base-string
+           #:normalize-to-simple-string #:copy-as-simple-string)
   (:export #:hash-digest-vector-to-hex-string
            #:sha-256-string #:sha-256-vector 
            #:sha3-512-string #:sha3-512-vector

--- a/src/tests/emotiq-test.lisp
+++ b/src/tests/emotiq-test.lisp
@@ -31,6 +31,55 @@
 
 
 
+;;;; Normalizing Strings as Simple Strings
+
+
+(defparameter *normalizing-string-test-cases*
+  ;; format:
+  ;;  ((descriptive-name <string corresponding to description>) ...)
+  `((simple-base-string
+     ,(make-array 3 :element-type 'base-char :initial-element #\t))
+    (test-simple-string
+     ,(make-array 3 :element-type 'base-char :initial-element #\t))
+    (test-adjustable-string
+     ,(make-array
+       3 :element-type 'character :initial-element #\s :adjustable t))
+    (test-adjustable-string-with-fill-pointer
+     ,(make-array
+       3 :element-type 'character :initial-element #\t :adjustable t
+       :fill-pointer 3))))
+
+(define-test normalizing-strings-as-simple-strings
+  (loop for (descriptive-name string)
+          in *normalizing-string-test-cases*
+        as normalized-base-string
+          = (normalize-to-base-string string)
+        as normalized-simple-string
+          = (normalize-to-simple-string string)
+        as normalized-base-string-correctly-p
+          = (etypecase normalized-base-string
+              (base-string t)
+              (simple-string nil)
+              (string nil))
+        as normalized-simple-string-correctly-p
+          = (etypecase normalized-simple-string
+              (base-string nil)
+              (simple-string t)
+              (string nil))
+        ;; Test to show that string is EQUAL to its base-string and
+        ;; simple-string equivalents, and then make sure normalized
+        ;; strings are of exactly the right types.
+        do (assert-equal string normalized-base-string)
+           (assert-equal string normalized-simple-string)
+           (assert-true normalized-base-string-correctly-p)
+           (assert-true normalized-simple-string-correctly-p)))
+  
+  
+     
+
+
+
+
 ;;;; Crypto
 
 

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -23,3 +23,49 @@
 (defmacro ovref (octet-vector index)
   "Macro (get'able and setf'able) to access octet-vector at index."
   `(aref (the octet-vector ,octet-vector) ,index))
+
+
+
+
+;;;; Normalizing Strings as Base Strings and Simple Strings
+
+(defun normalize-to-base-string (string)
+  "If STRING is not a base string, return a copy (via
+   copy-as-base-string) that is of type SIMPLE-BASE-STRING; otherwise,
+   return STRING itself. It is an error for STRING to contain
+   non-BASE-CHAR characters."
+  (etypecase string
+    (base-string string)
+    (string (copy-as-base-string string))))
+
+(defun copy-as-base-string (string)
+  "Return a freshly consed string of type SIMPLE-BASE-STRING, i.e., an
+  array with element-type BASE-CHAR, of the same (active) length as
+  and with all the same (active) elements as STRING copied over to the
+  same positions. It is an error for STRING to contain non-BASE-CHAR
+  characters."
+  (make-array
+   (length string)
+   :initial-contents string 
+   :element-type 'base-char))
+
+
+
+(defun normalize-to-simple-string (string)
+  "If STRING is either not a simple string or is of a proper subtype
+   of SIMPLE-STRING, return a copy that is of type simple-string;
+   otherwise, return STRING itself."
+  (etypecase string
+    (base-string (copy-as-simple-string string))
+    (simple-string string)      
+    (string (copy-as-simple-string string))))
+
+(defun copy-as-simple-string (string)
+  "Return a freshly consed string of type SIMPLE-STRING, i.e., an
+  array with element-type CHARACTER, of the same (active) length as
+  and with all the same (active) elements as STRING copied over to the
+  same positions."
+  (make-array
+   (length string)
+   :initial-contents string 
+   :element-type 'character))


### PR DESCRIPTION
- This introduces base-string and simple-string as the normalized
  string types. When strings are created via Lisp READ, as well as
  when they're created in myriad ways through code, they can be of
  various types, such as simple-base-string, simple-string, or string,
  but these result in different encoding types, and this will result
  in different encoding using lisp object encoder system.  This change
  provides functions to coerce (copy if needed) and to simply copy
  unconditionally a string as an equivalent string of one of these two
  particular types, i.e., either BASE-STRING or SIMPLE-STRING.
- Note: the motivation for this was to deal with the practical issues
  arising from the fact that string literals with ASCII characters in
  SBCL are by default created as strings of type SIMPLE-STRING whereas
  in CCL and LispWorks they are of type BASE-STRING.  This results in
  lossage around loenc:encode/decode when applied to such strings
  going cross platform.