### PR TITLE
Correction to string normalizer utility for simple-base-string case

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -9,7 +9,7 @@
            #:octet-vector-to-hex-string #:hex-string-to-octet-vector
            #:string-to-octet-vector
 
-           #:normalize-to-base-string #:copy-as-base-string
+           #:normalize-to-simple-base-string #:copy-as-simple-base-string
            #:normalize-to-simple-string #:copy-as-simple-string)
   (:export #:hash-digest-vector-to-hex-string
            #:sha-256-string #:sha-256-vector 

--- a/src/tests/emotiq-test.lisp
+++ b/src/tests/emotiq-test.lisp
@@ -52,26 +52,28 @@
 (define-test normalizing-strings-as-simple-strings
   (loop for (descriptive-name string)
           in *normalizing-string-test-cases*
-        as normalized-base-string
-          = (normalize-to-base-string string)
+        as normalized-simple-base-string
+          = (normalize-to-simple-base-string string)
         as normalized-simple-string
           = (normalize-to-simple-string string)
-        as normalized-base-string-correctly-p
-          = (etypecase normalized-base-string
-              (base-string t)
+        as normalized-simple-base-string-correctly-p
+          = (etypecase normalized-simple-base-string
+              (simple-base-string t)
+              (base-string nil)
               (simple-string nil)
               (string nil))
         as normalized-simple-string-correctly-p
           = (etypecase normalized-simple-string
+              (simple-base-string nil)
               (base-string nil)
               (simple-string t)
               (string nil))
-        ;; Test to show that string is EQUAL to its base-string and
-        ;; simple-string equivalents, and then make sure normalized
-        ;; strings are of exactly the right types.
-        do (assert-equal string normalized-base-string)
+        ;; Test to show that string is EQUAL to its simple-base-string
+        ;; and simple-string equivalents, and then make sure
+        ;; normalized strings are of exactly the right types.
+        do (assert-equal string normalized-simple-base-string)
            (assert-equal string normalized-simple-string)
-           (assert-true normalized-base-string-correctly-p)
+           (assert-true normalized-simple-base-string-correctly-p)
            (assert-true normalized-simple-string-correctly-p)))
   
   

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -27,22 +27,22 @@
 
 
 
-;;;; Normalizing Strings as Base Strings and Simple Strings
+;;;; Normalizing Strings as Simple Base Strings and Simple Strings
 
-(defun normalize-to-base-string (string)
+(defun normalize-to-simple-base-string (string)
   "If STRING is not a base string, return a copy (via
-   copy-as-base-string) that is of type SIMPLE-BASE-STRING; otherwise,
-   return STRING itself. It is an error for STRING to contain
-   non-BASE-CHAR characters."
+   copy-as-simple-base-string) that is of type SIMPLE-BASE-STRING;
+   otherwise, return STRING itself. It is an error for STRING to
+   contain non-BASE-CHAR characters."
   (etypecase string
-    (base-string string)
-    (string (copy-as-base-string string))))
+    (simple-base-string string)
+    (string (copy-as-simple-base-string string))))
 
-(defun copy-as-base-string (string)
-  "Return a freshly consed string of type SIMPLE-BASE-STRING, i.e., an
-  array with element-type BASE-CHAR, of the same (active) length as
-  and with all the same (active) elements as STRING copied over to the
-  same positions. It is an error for STRING to contain non-BASE-CHAR
+(defun copy-as-simple-base-string (string)
+  "Return a freshly consed string of type SIMPLE-BASE-STRING, i.e., a
+  simple array with element-type BASE-CHAR, with length and elements
+  the same as those (active) for STRING copied over to the same
+  positions. It is an error for STRING to contain non-BASE-CHAR
   characters."
   (make-array
    (length string)


### PR DESCRIPTION
- to test: (asdf:test-system :emotiq)
  - runs lisp-unit test normalizing-strings-as-simple-strings
  - source file: src/tests/emotiq-test.lisp

----

- Both STRING and BASE-STRING can have fill pointers or be adjustable,
  not SIMPLE-STRING or any SIMPLE-BASE-STRING.

- Base-string can have fill pointers and be adustable. These would not
  be passable to/from C foreign functions, presumably, I don't
  think.

- So it was incorrect to have normalizers SIMPLE-STRING and
  BASE-STRING. Instead, it should have been SIMPLE-STRING and
  SIMPLE-BASE-STRING. So that's what this commit changes.