### PR TITLE
The test harness may be used from an interactive shell again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,8 @@ variables:
   LWPRO: lwpro
   LWPRO_MACOS_64: lwpro
   lisp: lisp-wrapper.sh
+# Add ASDF systems here to test them  
   systems: ":cosi-bls-tests :crypto-pairings :gossip-tests"
-
 
 stages:
   - test
@@ -24,8 +24,6 @@ before_script:
   stage: test
   retry: 1
   script:
-    - ci/with-timeout.sh 'lisp-wrapper.sh -e "(when (ql:quickload :cosi-bls) (uiop:quit 0))"'
-    - ci/with-timeout.sh 'lisp-wrapper.sh -e "(when (asdf:load-system :cosi-bls) (uiop:quit 0))"'
     - ci/with-timeout.sh etc/test-harness.bash
 
 test:linux:lispworks:

--- a/etc/test-harness.bash
+++ b/etc/test-harness.bash
@@ -9,11 +9,11 @@
 #   Whitespace separated list of systems to test.
 #
 #
-# For example
+# For example the following entry
 #
-#   lisp=ccl systems=":gossip-test :cosi-bls" bash test-harness.bash
+#   lisp=ccl systems=":gossip-tests :cosi-bls" bash test-harness.bash
 #
-# would invoke the test harness using `ccl` on the `gossip-test` and
+# would invoke the test harness using `ccl` on the `gossip-tests` and
 # `cosi-bls` systems.
 #
 # BUGS
@@ -28,9 +28,8 @@ DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 lisp=${lisp:-'ros'}
 
 # The default whitespace list of systems to test
-systems=${systems:-":emotiq/blockchain
-                    :crypto-pairings/t
-                    :core-crypto"}
+systems=${systems:-":crypto-pairings/t
+                    :cosi-bls"
 
 echo Test harness invoked using implementation: ${lisp}
 echo $(${lisp} --eval '(format t "~&~a ~a~&" (lisp-implementation-type)(lisp-implementation-version))(uiop:quit 0)' < /dev/null)

--- a/etc/test-harness.bash
+++ b/etc/test-harness.bash
@@ -29,7 +29,7 @@ lisp=${lisp:-'ros'}
 
 # The default whitespace list of systems to test
 systems=${systems:-":crypto-pairings/t
-                    :cosi-bls"
+                    :cosi-bls"}
 
 echo Test harness invoked using implementation: ${lisp}
 echo $(${lisp} --eval '(format t "~&~a ~a~&" (lisp-implementation-type)(lisp-implementation-version))(uiop:quit 0)' < /dev/null)

--- a/etc/test-harness.bash
+++ b/etc/test-harness.bash
@@ -33,7 +33,7 @@ systems=${systems:-":emotiq/blockchain
                     :core-crypto"}
 
 echo Test harness invoked using implementation: ${lisp}
-echo $(${lisp} --eval '(format t "~&~a ~a~&" (lisp-implementation-type)(lisp-implementation-version))(uiop:quit 0)')
+echo $(${lisp} --eval '(format t "~&~a ~a~&" (lisp-implementation-type)(lisp-implementation-version))(uiop:quit 0)' < /dev/null)
 
 for system in ${systems}; do
     rm -rf ~/.cache/common-lisp/


### PR DESCRIPTION
To test, one should be able to invoke the test harness from an interactive shell via:

```
lisp=ccl ./etc/test-harness.bash
```

where the `lisp=ccl` may be replaced via setting a reference to the path of the Lisp which one wishes to run the test harness under.