### PR TITLE
Dbm 0610a

### DIFF
--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -795,11 +795,12 @@ check that each TXIN and TXOUT is mathematically sound."
   )
 
 (defmethod short-id (x)
-  (let ((str (base58-str x)))
-    (if (> (length str) 20)
+  (let* ((str (base58-str x))
+         (len (length str)))
+    (if (> len 20)
         (concatenate 'string (subseq str 0 10)
                      ".."
-                     (subseq str (- (length str) 10)))
+                     (subseq str (- len 10)))
       str)))
 
 ;; ------------------------------

--- a/src/Crypto/ecc-package.lisp
+++ b/src/Crypto/ecc-package.lisp
@@ -94,6 +94,7 @@ THE SOFTWARE.
    :int=
    :vec=
    :sbs
+   :short-str
    ))
 
 (defpackage :hash

--- a/src/Crypto/hash.lisp
+++ b/src/Crypto/hash.lisp
@@ -176,4 +176,11 @@ THE SOFTWARE.
 (defmethod hash= ((hash1 hash) (hash2 hash))
   (vec= hash1 hash2))
 
+(defmethod print-object ((obj hash) out-stream)
+  (if *print-readably*
+      (call-next-method)
+    (format out-stream "#<~A ~A >"
+            (class-name (class-of obj))
+            (short-str (hex-str obj)))
+    ))
 

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -316,6 +316,15 @@ THE SOFTWARE.
 Usually, they are in big-endian representation for PBC library."
   (crypto-val-vec x))
 
+(defmethod print-object ((obj crypto-val) out-stream)
+  (if *print-readably*
+      (call-next-method)
+    ;; else
+    (format out-stream "#<~A ~A >"
+            (class-name (class-of obj))
+            (short-str (hex-str obj)))
+    ))
+
 ;; -------------------------------------------------
 ;; Useful subclasses
 

--- a/src/Crypto/vec-repr.lisp
+++ b/src/Crypto/vec-repr.lisp
@@ -165,6 +165,15 @@ THE SOFTWARE.
             (class-name (class-of obj))
             (ub8v-repr obj))))
 
+(defun short-str (str)
+  (let ((len (length str)))
+    (if (< len 40)
+        str
+      (format nil "~A...~A"
+              (subseq str 0 20)
+              (subseq str (- len 20)))
+      )))
+
 ;; ----------------------------------------------------------
 ;; Base58 encodes integers into character strings of the restricted
 ;; alphabet.


### PR DESCRIPTION
Add PRINT-OBJECT methods on HASH and CRYPTO-VAL to display abbreviated hex strings in printout in REPL (when *PRINT-READABLY* = NIL). Abbreviated form is 20 chars ... 20 chars.

Example:
PBC 17 > (setf k (make-key-pair :dave))
#<KEYING-TRIPLE 402000FAEB>

PBC 18 > (keying-triple-pkey k)
#<PUBLIC-KEY 007A9D1B943ABD9AF9BE...74EFA17CA8704E00FE01 >

HASH covers subclasses HASH/256, HASH/384, HASH/512. CRYPTO-VAL covers all PBC related quantities - ECC points in G_1, G_2, pairing field, secret and public keys, signatures

Impact: REPL, and Logging

Second Example with *PRINT-READABLY* = T:
PBC 26 > (let ((*print-readably* t)) (print (keying-triple-pkey k)))

#.(make-instance 'PUBLIC-KEY :value #.(BEV (HEX "007A9D1B943ABD9AF9BECD889D2BCF1FBF2C8493B0C17971DEB58B95900DBA12A7E360D6CDBC93DF5FC4870821287AB71C661D084002A69AA6015F612769F6E128DFB257B539DA6E9D26EF9502A39DA03ED6E6369DF24B2CB34D2C170C1B655D0E54AD840FA9EBCA9A74EFA17CA8704E00FE01"))) 

#<PUBLIC-KEY 007A9D1B943ABD9AF9BE...74EFA17CA8704E00FE01 > ;; REPL print of result
