### PR TITLE
Fix dropping into CCL debugger in GOSSIP:PING-OTHER-HOSTS

### DIFF
--- a/src/Cosi-BLS/cosi-netw-xlat.lisp
+++ b/src/Cosi-BLS/cosi-netw-xlat.lisp
@@ -178,11 +178,13 @@ THE SOFTWARE.
 
 ;;; For binary delivery, we need to allocate keypair memory at
 ;;; runtime.  
-(let (hmac-keypair)
+(let ((hmac-keypair nil)
+      (hmac-keypair-mutex (mpcompat:make-lock)))
   (defun hmac-keypair ()
     (unless hmac-keypair
-      (setf hmac-keypair
-            (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid)))))
+      (mpcompat:with-lock (hmac-keypair-mutex)
+        (setf hmac-keypair
+              (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid))))))
     hmac-keypair)
   (defmethod socket-send (ip port dest msg)
     (let* ((payload (make-hmac (list* dest msg)

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -714,7 +714,6 @@ library, and we don't want inconsistent state. Calls to SET-GENERATOR
 also mutate the state of the lib, and so are similarly protected from
 SMP access. Everything else should be SMP-safe."
   (mpcompat:with-lock (*crypto-lock*)
-    (load-dlls)
     (let ((prev   *curve*)
           (params (or params
                       *curve-fr449-params*)))
@@ -723,6 +722,7 @@ SMP access. Everything else should be SMP-safe."
       (when (or params-supplied-p
                 (null *curve*))
         (setf *curve* nil) ;; in case we fail
+	(load-dlls)
         (with-accessors ((txt  curve-params-pairing-text)
                          (g1   curve-params-g1)
                          (g2   curve-params-g2)) params

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -142,17 +142,13 @@ THE SOFTWARE.
 
 (defun load-dev-dlls ()
   "loads the DLLs (.so and .dylib) at runtime, from pre-specified directories"
+  (pushnew (asdf:system-relative-pathname :emotiq "../var/local/lib/")
+           cffi:*foreign-library-directories*)
   (cffi:define-foreign-library
-   libpbc
-   (:darwin #.(concatenate 
-	       'string 
-	       (namestring (asdf:system-relative-pathname 'emotiq "../var/local/lib"))
-	       "/libLispPBCIntf.dylib"))
-   (:linux #.(concatenate 
-	      'string 
-	      (namestring (asdf:system-relative-pathname 'emotiq "../var/local/lib"))
-	      "/libLispPBCIntf.so"))
-   (t (:default "libLispPBCIntf"))))
+      libpbc 
+    (:darwin "libLispPBCIntf.dylib")
+    (:linux "libLispPBCIntf.so")
+    (t (:default "libLispPBCIntf"))))
 
 (defun load-production-dlls ()
   "loads the DLLs (.so and .dylib) at runtime, from the current directory"
@@ -166,7 +162,7 @@ THE SOFTWARE.
   "load the dev or production dlls at runtime"
   (if (emotiq:production-p)
       (load-production-dlls)
-    (load-dev-dlls))
+      (load-dev-dlls))
   (cffi:use-foreign-library libpbc))
 
 ;; -----------------------------------------------------------------------

--- a/src/gossip/gossip.asd
+++ b/src/gossip/gossip.asd
@@ -2,12 +2,12 @@
   :name "Gossip"
   :description "Gossip protocols"
   :author "Shannon Spires <svs@emotiq.ch>"
-  :version "0.2.1"
+  :version "0.2.2"
   :maintainer "Shannon Spires <svs@emotiq.ch>"
   :depends-on (gossip/config
                emotiq/logging
                quicklisp
-	       uiop
+               uiop
                mpcompat
                key-value-store
                actors

--- a/src/gossip/gossip.lisp
+++ b/src/gossip/gossip.lisp
@@ -1961,11 +1961,13 @@ gets sent back, and everything will be copacetic.
 
 ;;; The need for this is rather dubious.  No one other than the
 ;;; signing node can authenticate this HMAC. 
-(let (hmac-keypair)
+(let ((hmac-keypair nil)
+      (hmac-keypair-mutex (mpcompat:make-lock)))
   (defun hmac-keypair ()
     (unless hmac-keypair
-      (setf hmac-keypair
-            (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid)))))
+      (mpcompat:with-lock (hmac-keypair-mutex)
+        (setf hmac-keypair
+              (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid))))))
     hmac-keypair)
   (defun sign-message (msg)
     "Sign and return an authenticated message packet. Packet includes


### PR DESCRIPTION
Guard multi-threaded creation of keypairs via a simple mutex.  Without
this patch, the invocation of GOSSIP:PING-OTHER-HOSTS with enough
hosts would fail as more than one thread would attempt to create the
hmac keypair for the socket connection simultaneously.

We proactively fix similar code in COSI-BLS which would be suceptible
to the same sort of bug if it were potentially called by many threads.
