### PR TITLE
MTE fix simulator

### DIFF
--- a/src/election-sim.lisp
+++ b/src/election-sim.lisp
@@ -31,7 +31,8 @@ THE SOFTWARE.
 
 (defvar *beacon-interval*  20)
 
-;; ordered list/vector of all known stakeholders
+;; list of lists of a public key and its associated stake
+;; 
 ;; in real life, this should be an ordered list/vector of *real-nodes*
 ;; in the simulator, 1 machine, this is a list of all nodes (fake and real)
 ;; In the simulator, we only hold mock elections, and print the
@@ -40,7 +41,7 @@ THE SOFTWARE.
 (defvar *all-nodes*  nil) 
 
 (defun set-nodes (node-list)
-  "Node-list is a list of (public-key stake-amount) pairs"
+  "NODE-LIST is a list of (public-key stake-amount) pairs"
   (ac:pr (format nil "election set-nodes ~A" node-list))
   (assert node-list)
   (setf *all-nodes* node-list))

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -90,11 +90,12 @@
                 :components ((:file "node")))))
 
 (defsystem "emotiq/sim"  ;; a simulated node
-  :depends-on (emotiq/cli)
+  :depends-on (emotiq/cli
+               alexandria)
   :components ((:module source
                 :pathname "./"
                 :components ((:file "handler")
                              (:file "election-sim")
-                             (:file "node-sim")))))
+                             (:file "node-sim" :depends-on (election-sim))))))
 
 

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -11,7 +11,7 @@
   (assert bool-condition))
 
 (defun initialize (&key
-                     (cosi-prepare-timeout 10)
+                     (cosi-prepare-timeout 40)
                      (cosi-commit-timeout 10)
                      (executive-threads nil)
                      (nodes 8)
@@ -21,8 +21,14 @@
 
 The simulation can be configured to run across the number of EXECUTIVE-THREADS 
 
-COSI-PREPARE-TIMEOUT specifies how many seconds that cosi leaders wait for responses during prepare phase. 
-COSI-COMMIT-TIMEOUT specifies how many seconds that cosi leaders wait for responses during commit phase. 
+COSI-PREPARE-TIMEOUT specifies how many seconds that cosi leaders wait
+for responses during prepare phase.  The default value is 40.  For
+simulations involving computational expensive cloaked transactions
+across many nodes, this value may need to be larger to allow the
+blocks to be sealed.
+
+COSI-COMMIT-TIMEOUT specifies how many seconds that cosi leaders wait
+for responses during commit phase.
 
 Prepare can possibly take longer than commit, because the block may contain txns that a witness has not
 yet seen (and, therefore, needs to validate the unseen txn(s))
@@ -167,8 +173,8 @@ This will spawn an actor which will asynchronously do the following:
         *tx-2*           nil
         *tx-3*           nil)
 
-  (cosi-simgen:reset-nodes) 
-
+  (cosi-simgen:reset-nodes)
+ 
   (emotiq/elections:make-election-beacon)
                                          
   ;(ac:spawn  ;; cosi-handlers assumes that there is one block in the blockchain, if you spawn here,

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -209,7 +209,7 @@ the cosi-simgen implementation of the simulator."
   (cosi-simgen:node-blockchain cosi-simgen:*top-node*))
 
 (defun kill-beacon ()
-  (emotiq/elections::kill-beacon))
+  (emotiq/elections:kill-beacon))
 
 (defun nodes ()
   "Return a list of all nodes under simulation"

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -108,6 +108,7 @@
   (:export 
    #:set-nodes
    #:make-election-beacon
+   #:kill-beacon
    #:hold-election))
 
 (defpackage emotiq/filesystem

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -95,7 +95,7 @@
 
    
    #:*user-1* #:*user-2* #:*user-3*
-   #:*tx-1* #:*tx-2* #:*tx-3*
+   #:*tx-1* #:*tx-2* 
 
    #:eassert
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -87,6 +87,9 @@
    #:run
 
    #:blocks
+   #:nodes
+   #:keys-and-stakes
+   
    #:create-transaction
    #:force-epoch-end
 

--- a/src/simulation.md
+++ b/src/simulation.md
@@ -1,12 +1,53 @@
 # Running the local node simulation
 
 ## Running
+
+### Cloaked
 ```lisp
-(system:run-shell-command "rm -rf ~/.cache/common-lisp/")
 (ql:quickload :emotiq/sim)
 (emotiq/sim:initialize)  ;; takes several keywords - see node-sim.lisp
-(emotiq/sim::run) or (emotiq/sim::run :cloaked nil)
+(emotiq/sim:run) 
 ```    
+
+### Uncloaked 
+```lisp
+(ql:quickload :emotiq/sim)
+(emotiq/sim:initialize)  ;; takes several keywords - see node-sim.lisp
+(emotiq/sim:run :cloaked nil)
+```
+
+## Explanation    
+
+The simulation performs the following steps:
+
+  1.  Create a genesis transaction with MONETARY-SUPPLY coins.  
+      Transact 1000 coins to *USER-1*.  The resulting transaction
+      can be referenced via *TX-1*.
+
+  2.  In the transaction references as *TX-2*, *USER-1* sends 500
+      coins to *USER-2*, 490 coins to *USER-3*, with a fee of 10
+      coins.
+
+Various diagnostic messages from the actor threads will
+appear to `cl:*standard-output*` and `cl:*standard-error*`.
+
+After the simulation completes, one may inspect the created blocks
+via:
+```lisp
+(emotiq/sim:blocks)
+```
+
+The specials `*tx-1*` and `*tx-2*` will hold references to the
+transactions.
+
+The specials `*user-1*` `*user-2*` `*user-3*` will hold references to the
+user identities.
+
+Subsequently, one may use the `spend` and `spend-list` functions to
+create further transactions.  
+
+
+## Notes
 ### helpers...
 ```lisp
 (progn
@@ -17,57 +58,20 @@
   (emotiq/sim:initialize)
   (emotiq/sim::run :cloaked nil))
 ```    
-## for pt linux
+
+### for pt linux
 ```lisp
 (system:run-shell-command "rm -rf ~/.cache/common-lisp/")
 (ql:quickload :emotiq/sim)
 (emotiq/sim:initialize :cosi-prepare-timeout 60 :cosi-commit-timeout 60 :executive-threads 8)
 ```
 ```lisp
-(emotiq/sim::run :cloaked t)
+(emotiq/sim:run :cloaked t)
 ```
 or
 ```lisp
-(emotiq/sim::run :cloaked nil)
+(emotiq/sim:run :cloaked nil)
 ```
 
-## Explanation    
 
-The simulation spawns an actor which will asynchronously to perform
-the following steps.  AMOUNT is by default 1000, which may be
-configured in parameters to RUN:
-
-  1.  Create a genesis transaction with AMOUNT coins.  Transact AMOUNT
-      coins to `*user-1*`.  The resulting transaction can be referenced
-      via `*tx-1*`.
-
-  2.  Transfer the AMOUNT of coins from `*user-1*` to `*user-2*` as `*tx-2*`.
-
-  3.  Transfer `(- amount (floor (/ amount 2)))` coins from `*user-2*` to
-      `*user-3*` as `*tx-3*`.
-
-  4.  Force these transactions to be commited as part of the block.
-
-Various diagnostic messages from the actor threads will
-appear to `cl:*standard-output*`.
-
-After the simulation completes, one may inspect the created blocks
-via:
-```lisp
-(emotiq/sim:blocks)
-```
-
-The specials `*tx-1*` `*tx-2*` `*tx-3*` will hold references to the
-transactions.
-
-The specials `*user-1*` `*user-2*` `*user-3*` will hold references to the
-user identities.
-
-Subsequently, one may use the `spend` and `spend-list` functions to
-create further transactions.  
-
-After transactions have been created, one may force a new block to be
-created via:
-```lisp
-(force-epoch-end)
-```
+    


### PR DESCRIPTION
If we define a working simulator as that which produces an observable block after `emotiq/sim:run` is executed, the simulator has been broken for cloaked transaction simulations since

<https://github.com/emotiq/emotiq/commit/2d2875ab1f7a05157b6f1efce8b700868bd7ff04>
```
git commit 2d2875ab1f7a05157b6f1efce8b700868bd7ff04
2018-05-29 08:46 -0700 David McClain <dbm@emotiq.ch>
Merge branch 'dev' into dbm

# Conflicts:
#	src/Cosi-BLS/cosi-netw-xlat.lisp
#	src/node-sim.lisp
```

The problem lies in the timeout of the prepare phase as controlled by ` cosi-simgen:*cosi-prepare-timeout*`.  This commit set the simulator to use a timeout of 10 seconds in waiting for the prepare phase with cloaked transactions.  During this time, all simulated nodes other than the leader must run the computationally expensive Bulletproof range proofs on amounts within the block.  If a Byzantine-fault tolerant threshhold of witnesses willing to commit are not received before this timeout occurs, the block is never sealed.  

This pull request changes the default timeout for the prepare phase to be 40 seconds which is enough for a 2013 8 core  Intel Core Duo 2 to simulate a four network node verifying cloaked transaction.  If need, the timout value may be set via the `:cosi-prepare-timeout` parameter to the `cosi/sim:initialize` function.

The simulator has been roundly violated since I last touched her, so I removed things that were no longer necessary, updated the docstring to reflect the true nature of the `emotiq/sim:run`, and introduced the `emotiq/sim:nodes` function to return a list of simulated nodes so that developers can inspect each nodes' version of the mempool, utxo, blockchain, etc. references.  
