### PR TITLE
call actors:set-executive-pool instead of setting *nbr-execs* directly

### DIFF
--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -39,8 +39,7 @@ configured simulation will have the integer number of NODES as
 witnesses."
   (setf actors::*maximum-age* 120)
   (when executive-threads
-    (setf actors::*nbr-execs*
-          executive-threads))
+    (actors:set-executive-pool executive-threads))
   (when (or new-configuration-p
               (not (and (probe-file cosi-simgen:*default-data-file*)
                         (probe-file cosi-simgen:*default-key-file*))))


### PR DESCRIPTION
node-sim call actors:set-executive-pool instead of setting actors::*nbr-execs* directly.

Lightly tested.  Load and initialize :emotiq/sim using a different value of :executive-threads.  Verify that *nbr-execs* has been changed.  Used "Process Browser" to see that the number of "Actor Executive" threads was changed.  (8 down to 5 in my test).