### PR TITLE
Introduce new transactions (smart contract, with 'chainlisp').

### DIFF
--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -388,6 +388,8 @@ Later it may become an ADS structure"
   nil)
 
 (defmethod node-check-transaction ((msg transaction))
+  (when *newtx-p*                       ; sanity check
+    (error "This method must not be called in new-transactions mode."))
   (when (check-transaction-math msg)
     (let ((key (bev-vec (hash/256 msg))))
       (when (gethash key *mempool*)


### PR DESCRIPTION
New transactions are on by default in this commit, but old code continues to
live side by side for now and is switched on or off via switch parameter
cosi/proofs:*newtx-p*. The parameter is true by default, meaning new
transactions are enabled by default.

Module node-sim.lisp has been updated to have new run function run-new-tx which
can only work with new transactions. It uses new functionality to create a
genesis block (no longer a "genesis UTXO").  It includes a few very basic spend
transactions as well as a couple of intentional attempted double-spend
transactions that should be rejected.

As the current test stands (EMOTIQ/SIM:RUN-NEW-TX) runs and thinks for about a
minute, then calls a new transaction "dumper" to display all transactions on the
blockchain so far, showing there are two blocks with a total of four
transactions.  Other output shows two rejected attempted double-spends.

This commit introduces a new module new-transactions.lisp and a new package
COSI/PROOFS/NEWTX, intended to be temporary, in which the class transaction is
defined (the old transactions are defined with the same name in the package
COSI/PROOFS).  Later, work will be done on decommissioning the old transactions,
and presumably on rethinking names, e.g., not to contain "new", etc.

Logging/messaging/signaling are at this point a hodge-podge. This commit does
introduce the emerging emotiq:note facility, and begins using it to
log/display/warn about things, but there numerous are other conventions or lack
thereof at work.

Expect cleanups, forthcoming. Highly notably missing from this commit and
needed/planned for subsequent commits: cloaked transactions; other types of
transactions: stake, etc.; some of the types of validation that was
lost/commented out in this commit (with comments); creation of coinbase
transaction at beginning of each block and computing and including fees,
including fees; using priority age|fees to prune transactions from mempool for
block if too many; including input scripts (including witness data) in block
(i.e., block header) for ultimate validation; UTXO database; blockchain on disk
(persistent storage); genesis block creation is still wild west; etc. (This list
is not necessarily exhaustive.)