### PR TITLE
Clean up initial commit of new transactions around mempool clearing.

### DIFF
--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -388,6 +388,8 @@ Later it may become an ADS structure"
   nil)
 
 (defmethod node-check-transaction ((msg transaction))
+  (when *newtx-p*                       ; sanity check
+    (error "This method must not be called in new-transactions mode."))
   (when (check-transaction-math msg)
     (let ((key (bev-vec (hash/256 msg))))
       (when (gethash key *mempool*)

--- a/src/Cosi-BLS/new-transactions.lisp
+++ b/src/Cosi-BLS/new-transactions.lisp
@@ -1087,6 +1087,13 @@ returns the block the transaction was found in as a second value."
   (let ((key (get-hash-key-of-transaction transaction)))
     (setf (gethash key cosi-simgen:*mempool*) transaction)))
 
+(defun remove-transaction-from-mempool (transaction mempool)
+  "Remove TRANSACTION, a transaction instance, from MEMPOOL, and return true if
+   there was such an entry or false (nil) otherwise."
+  (remhash (get-hash-key-of-transaction transaction) mempool))
+
+
+
 
 
 (defun make-transaction-inputs (input-specs)
@@ -1356,46 +1363,23 @@ ADDRESS here is taken to mean the same thing as the public key hash."
 
 
 (defun clear-transactions-in-block-from-mempool (block)
-  ;; (format t "~2%***   We added a block. About to clear mempool. Here's what's there before...")
-  ;; (cosi/proofs/newtx:dump-txs :mempool t)
-  (format t "~%   Now clearing transactions from mempool . . . ")
-
-  ;; inefficient clearing algorithm -- ok for now, improve later!
+  "Remove transactions that have just been added the block from the mempool that
+   is globally bound to cosi-simgen:*mempool*. Note that these transactions may
+   not be identical EQ Lisp instances, so even if you're holding a pointer to
+   transaction that's in the mempool in your hand, to find the corresponding
+   instance in the block, you must compare must compare two instances using
+   their hash keys, not EQ. That also acts as a vefification that the contents
+   are exactly the same, have not undergone any changes after being encoded,
+   transferred from one node to the other over the network, and decoded, etc."
   (loop with mempool = cosi-simgen:*mempool*
-        with transactions = (mapcar #'hash:hash/256 (cosi/proofs:block-transactions block))
-        with block-tx-count = (length transactions)
-        ;; initially (format t "~%Transactions count in block: ~d" (length transactions))
-        ;;           (cosi/proofs/newtx:dump-txs :block block)
-        for tx being each hash-value
-          of mempool 
-            using (hash-key key)
-        when (member (hash:hash/256 tx) transactions :test #'hash:hash=)
-          collect tx into removed-txs
-          and do (remhash key mempool)
-             ;; thought I saw something bad happen here:
-                 (assert (null (gethash key mempool)) () "why doesn't remhash work?!")
+        for transaction in (cosi/proofs:block-transactions block)
+        count (remove-transaction-from-mempool transaction mempool)
+          into n-removed
         finally
-           ;; check that there were a few transactions in the block
-           ;; and in the mempool in common and that all the ones in
-           ;; the block are no longer in the mempool
-           (when (= block-tx-count 0)
-             (warn "***   NEWTX: there were zero txs in block? strange! [~d tx removed from mempool] ***"
-                   removed-txs))
-           (when (= (length removed-txs) 0)
-             (warn "***   NEWTX: there were zero txs removed from mempool? That's weird! [~d tx in block] ***"
-                   block-tx-count))
-           (let* ((txs-in-mempool
-                    (loop for tx being each hash-value of cosi-simgen:*mempool*
-                          collect tx))
-                  (intersection (intersection txs-in-mempool transactions)))
-             (format t "~2%")
-             (when intersection
-               (warn
-                "***   NEWTX: there are now STILL transactions (~d) in the mempool from block. How?! [~d in block/~d removed from mempool]"
-                (length intersection)
-                block-tx-count
-                removed-txs))))
-  (format t "~%   DONE.~%")
-  ;; (format t "~%   Now here's what's in mempool after, take a look ...")
-  ;; (cosi/proofs/newtx:dump-txs :mempool t)
-  )
+           (format t "~%Removed ~d transaction~p from mempool.~%"
+                   n-removed n-removed)
+           (cosi/proofs/newtx:dump-txs :mempool t)))
+
+;; Modularity issue: note that this should not really "know" that
+;; block-transactions is list. It is now specified as sequence, and it's left
+;; open for it to become a merkle tree; clean up later!  -mhd, 6/20/18


### PR DESCRIPTION
Added remove-transaction-from-mempool, which knows to use
get-hash-key-of-transaction to get its key. That eliminates whole
reason for the bug earlier (while preparing the previous commit) of
using the old-transactions-style key (completely my fault), which
required the painful and clever coding workaround that PT figured out,
essentially rehashing both the transactions in the block and the
transactions in the mempool and then comparing their hashes using
hash=.

Hopefully, it's clearer now with this change.  Added an error message
by node-check-transaction in the case of *newtx-p* just for emphasis.

To test: run with newtx mode, see the right number of Tx's (4)
dumped. To test old: restart, and run with old tx mode, see right
number Tx's (2) eventually built.