### PR TITLE
fire only one election - remove election beacon, call fire-election a…

### DIFF
--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -205,7 +205,6 @@ This will spawn an actor which will asynchronously do the following:
   (ensure-simulation-keys)
   (setf *genesis-output* nil *tx-1* nil *tx-2* nil)
   (cosi-simgen:reset-nodes)
-  (emotiq/elections:make-election-beacon)
   (let ((fee 10))    
     (ac:pr "Construct Genesis Block")
     (let* ((genesis-block
@@ -251,8 +250,6 @@ This will spawn an actor which will asynchronously do the following:
         (cosi/proofs/newtx:dump-tx signed-transaction)
         (broadcast-message :new-transaction-new :trn signed-transaction)
 
-        (sleep 5)
-      
         (let* ((user-2-public-key-hash
                  (cosi/proofs:public-key-to-address (pbc:keying-triple-pkey *user-2*)))
                (amount-2 500)
@@ -280,8 +277,6 @@ This will spawn an actor which will asynchronously do the following:
           (cosi/proofs/newtx:dump-tx signed-transaction)
           (broadcast-message :new-transaction-new :trn signed-transaction)
 
-          (sleep 5)
-
           (let* ((user-3-public-key-hash
                    (cosi/proofs:public-key-to-address (pbc:keying-triple-pkey *user-3*)))
                  (amount-3 350)
@@ -308,8 +303,6 @@ This will spawn an actor which will asynchronously do the following:
             (cosi/proofs/newtx:dump-tx signed-transaction)
             (broadcast-message :new-transaction-new :trn signed-transaction)
 
-            (sleep 5)
-
             ;; here: attempt a double-spend: (with same TxID)
             (setq signed-transaction
                   (cosi/proofs/newtx:make-and-maybe-sign-transaction
@@ -322,7 +315,6 @@ This will spawn an actor which will asynchronously do the following:
                     user-2-public-key-hash)
             (broadcast-message :new-transaction-new :trn signed-transaction)
 
-            (sleep 2)
             ;; here: attempt a double-spend: (with different TxID)
             (setq transaction-outputs
                   (cosi/proofs/newtx:make-transaction-outputs
@@ -334,12 +326,13 @@ This will spawn an actor which will asynchronously do the following:
                    :skeys (pbc:keying-triple-skey *user-2*)
                    :pkeys (pbc:keying-triple-pkey *user-2*)))
 
-            (sleep 2)
             (ac:pr (format nil "Broadcasting 5th TX [attempt to double-spend (diff TxID)]."))
             (format t "~%Tx 5 created/signed by user-2 (~a) [attempt to double-spend (diff TxID)], now broadcasting."
                     user-2-public-key-hash)
             (broadcast-message :new-transaction-new :trn signed-transaction)
 
+
+            (emotiq/elections:fire-election)
 
             ;; Dump the whole blockchain now after about a minute,
             ;; just before exiting:

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -110,6 +110,7 @@
   (:export 
    #:set-nodes
    #:make-election-beacon
+   #:fire-election
    #:kill-beacon
    #:hold-election))
 


### PR DESCRIPTION
…fter all txns have been broadcast ; result = 2 blocks (genesis, plus block with 3 txns)

This should run the simulator and execute exactly one election.  The Leader is determined at runtime.

The result should be 2 blocks.  The first block is the genesis block.  The 2nd block contains the 3 valid transactions.  Run-new-tx creates 5 transactions (plus genesis), but 2 of them are deliberate double-spends and are discarded

commands: (ql:quickload :emotiq/sim) (emotiq/sim:initialize) (emotiq/sim:run-new-tx)

This 'one-shot' election should be useful when debugging and when bringing the network up the first time.

@MarkD - sorry, this is probably what you wanted earlier, but it didn't occur to me until David showed me the trick.