### PR TITLE
Notes are not errors.

### DIFF
--- a/src/gossip/gossip-startup.lisp
+++ b/src/gossip/gossip-startup.lisp
@@ -104,10 +104,14 @@ with this list if desired."
        #+IGNORE ; #+OPENMCL ; these hemlock streams are just too slow when they get to a couple thousand lines
        ; in CCL, we'll just inspect the *log*
        (if (find-package :gui)
-           (setf *logstream* (funcall (intern "MAKE-LOG-WINDOW" :gui) "Emotiq Log"))
-           (setf *logstream* *standard-output*))
-       #+(or (not :openmcl) (not :shannon))
-       (setf *logstream* *error-output*)
+           (setf emotiq:*notestream* (funcall (intern "MAKE-LOG-WINDOW" :gui) "Emotiq Log"))
+           (setf emotiq:*notestream* *error-output*))
+       (setf emotiq:*notestream* 
+             #+(or (not :openmcl) (not :shannon))
+             *error-output*
+             #-(or (not :openmcl) (not :shannon))
+             nil
+             )
        (setf *logging-actor* (ac:make-actor #'actor-logger-fn))
        (setf *hmac-keypair-actor* (ac:make-actor #'actor-keypair-fn))
        (archive-log)

--- a/src/gossip/logging.lisp
+++ b/src/gossip/logging.lisp
@@ -1,14 +1,11 @@
 (in-package :gossip)
 
 (defvar *log* nil "Log of gossip actions.")
-(defvar *logstream* nil "Log stream for gossip log messages. This is in addition to the *log*, so it's fine if this is nil.")
 (defvar *logging-actor* nil "Actor which serves as gatekeeper to *log* to ensure absolute serialization of log messages and no resource contention for *log*.")
 (defvar *archived-logs* (make-array 10 :adjustable t :fill-pointer 0) "Previous historical logs")
 (defparameter *log-filter* t "t to log all messages; nil to log none")
 (defparameter *log-object-extension* ".log" "File extension for object-based logs")
 (defparameter *log-string-extension* ".txt" "File extension for string-based logs")
-(defparameter *log-dots* nil "True if you want the logger to send a period to *standard-output* for each log message.
-    Only used if *logstream* is nil. Mostly for debugging.")
 
 (defun log-exclude (&rest strings)
   "Prevent log messages whose logcmd contains any of the given strings. Case-insensitive."

--- a/src/gossip/package.lisp
+++ b/src/gossip/package.lisp
@@ -11,7 +11,6 @@
    #:clear-local-nodes
    #:*log-filter*
    #:*log*
-   #:*log-dots*
    #:make-graph
    #:solicit
    #:solicit-wait

--- a/src/gossip/tests/gossip-tests.lisp
+++ b/src/gossip/tests/gossip-tests.lisp
@@ -70,12 +70,10 @@
   ;;; in each thread if you're not careful.  So we set them here
   ;;; rather than bind them.
   (with-networking 
-      (let ((oldnodes *nodes*)
-            (oldlogdots *log-dots*))
+      (let ((oldnodes *nodes*))
         (set-protocol-style :neighborcast)
         (unwind-protect
              (progn 
-               (setf *log-dots* t)
                (setf *nodes* (gossip::make-uid-mapper))
                (clear-local-nodes)
                (make-test-network)
@@ -85,8 +83,7 @@
                       (uids (mapcar #'gossip::uid nodes)))
                                         ; do same test starting at every possible node
                  (mapc '%aliveness uids)))
-          (setf *nodes* oldnodes
-                *log-dots* oldlogdots)))))
+          (setf *nodes* oldnodes)))))
 
 ; (let ((*print-failures* t)) (run-tests '(key-value)))
 (define-test key-value
@@ -95,12 +92,10 @@
   ;;; in each thread if you're not careful.  So we set them here
   ;;; rather than bind them.
   (with-networking              
-    (let ((oldnodes *nodes*)
-          (oldlogdots *log-dots*))
+    (let ((oldnodes *nodes*))
       (set-protocol-style :neighborcast)
       (unwind-protect
            (progn
-             (setf *log-dots* t)
              (setf *nodes* (gossip::make-uid-mapper))
              (clear-local-nodes)
              (make-test-network)
@@ -110,21 +105,18 @@
                     (uids (mapcar #'gossip::uid nodes)))
             ;; do same test starting at every possible node
                (mapc '%key-value uids)))
-        (setf *nodes* oldnodes
-              *log-dots* oldlogdots)))))
+        (setf *nodes* oldnodes)))))
 
 (define-test partial-gossip "Test partial-gossip with parameter 2"
   ;;; careful with globals. Remember that they get a different value
   ;;; in each thread if you're not careful.  So we set them here
   ;;; rather than bind them.
   (with-networking
-    (let ((oldnodes *nodes*)
-          (oldlogdots *log-dots*))
+    (let ((oldnodes *nodes*))
       (set-protocol-style :gossip 2)
       (unwind-protect
            (let ((results nil)
                  (*log-filter* nil))
-             (setf *log-dots* t)
              (setf *nodes* (gossip::make-uid-mapper))
              (clear-local-nodes)
              (make-graph 100)
@@ -139,8 +131,7 @@
                                     (> x 90)
                                     t))
                               results))))
-        (setf *nodes* oldnodes
-              *log-dots* oldlogdots)))))
+        (setf *nodes* oldnodes)))))
 
 ; (let ((*print-failures* t)) (run-tests '(partial-gossip)))
 ; (let ((*print-failures* t)) (run-tests :all))

--- a/src/note.lisp
+++ b/src/note.lisp
@@ -1,10 +1,11 @@
 (in-package :emotiq)
 
+(defvar *notestream* *error-output* "Output stream for Emotiq notes")
+
 ;;; N.b. deliberately not a macro so we can theoretically inspect the
 ;;; call stack.
 (defun note (message-or-format &rest args)
   "Emit a note of progress to the appropiate logging system
-
 MESSAGE-OR-FORMAT is either a simple string containing a message, or
 a CL:FORMAT control string referencing the values contained in ARGS."
   (let ((formats '(simple-date-time:|yyyymmddThhmmssZ|
@@ -18,7 +19,7 @@ a CL:FORMAT control string referencing the values contained in ARGS."
                           nil
                           message-or-format
                           (if args args nil)))))
-      (format *error-output* message)
+      (when *notestream* (format *notestream* message))
       message)))
 
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -46,6 +46,7 @@
   (:export
    #:start-node)
   (:export
+   #:*notestream*
    #:note)
   (:export
    #:production-p


### PR DESCRIPTION
Add `*notestream*` as output of emotiq:note function. Initialize it to
`*error-output*`, but allow it to be rebound dynamically (even to nil
for no output at all) without being required to change the connotation
of `*error-output*` as "the stream for errors."

Get rid of `*log-dots*` and `*logstream*` since we're no longer using them.