### PR TITLE
Fix generate network mte 20180623a

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   LWPRO_MACOS_64: lwpro
   lisp: lisp-wrapper.sh
 # Add ASDF systems here to test them
-  systems: ":cosi-bls-tests :crypto-pairings :gossip-tests :emotiq/wallet"
+  systems: ":cosi-bls-tests :crypto-pairings :gossip-tests :emotiq/wallet :gossip-config-tests"
 
 stages:
   - test

--- a/src/gossip/config/generate.lisp
+++ b/src/gossip/config/generate.lisp
@@ -8,25 +8,27 @@
 (defun generate (records &key (root #p"/var/tmp/conf/"))
   "Generate configuration directories of an Emotiq testnet for RECORDS at directory ROOT
 
-
 The ROOT defaults to '/var/tmp/conf'."
-  (let ((key-records (generate-keys records)))
+  (let ((key-records (generate-keys records))
+        directories)
     (dolist (key-record key-records)
       (destructuring-bind (host eripa port (public private))
           key-record
         (declare (ignore private))
         (let ((directory (merge-pathnames (format nil "~a/" host) root)))
           (emotiq:note "~&Writing configuration to '~a'.~&" directory)
-             (ensure-directories-exist directory)
-             (write-local-machine-conf
-              (merge-pathnames "local-machine.conf" directory)
-              eripa port public)
-             (write-hosts-conf
-              (merge-pathnames "hosts.conf" directory)
+          (ensure-directories-exist directory)
+          (write-local-machine-conf
+           (merge-pathnames "local-machine.conf" directory)
+           eripa port public)
+          (write-hosts-conf
+           (merge-pathnames "hosts.conf" directory)
            key-records)
-             (write-keypairs-conf
-              (merge-pathnames "keypairs.conf" directory)
-           key-records))))))
+          (write-keypairs-conf
+           (merge-pathnames "keypairs.conf" directory)
+           key-records)
+          (push directory directories))))
+    directories))
 
 (defun generate-keys (records)
   (loop

--- a/src/gossip/config/t/generate-network.lisp
+++ b/src/gossip/config/t/generate-network.lisp
@@ -1,0 +1,42 @@
+(in-package :cl-user)
+
+(prove:plan 1)
+(let ((root #p"/var/tmp/emotiq/gossip/config/")
+      (network
+       `((:hostname "emq-01.aws.emotiq.ch"
+                    :ip "34.239.111.18"
+                    :port 65002)
+         (:hostname "emq-02.aws.emotiq.ch"
+                    :ip "52.12.224.84"
+                    :port 8080)
+         (:hostname "emq-02.aws.emotiq.ch"
+                    :ip "52.54.123.84"
+                    :port 65001)
+         (:hostname "emq-03.aws.emotiq.ch"
+                    :ip "52.54.224.84"
+                    :port 443)
+         (:hostname "emq-05.aws.emotiq.ch"
+                    :ip "34.217.39.58"
+                    :port 22))))
+  (ensure-directories-exist root)
+  (prove:ok (gossip/config:generate network :root root)
+            (format nil "Generating test network configuration in~&~t~a~& for ~&~s~&…"
+                    root network))
+  (let* ((hostname
+          (getf (alexandria:random-elt gossip/config:*aws-example*)
+                :hostname))
+         (p
+          (make-pathname
+           :directory `(,@(pathname-directory root) ,hostname)
+           :defaults root)))
+    (prove:plan 1)
+    (prove:ok (probe-file p)
+              (format nil "Generated configuration directory '~a' exists…"
+                      p))))
+;;; FIXME: remove directory from filesystem
+
+(prove:finalize)
+
+
+
+   

--- a/src/gossip/config/t/gossip-config-tests.asd
+++ b/src/gossip/config/t/gossip-config-tests.asd
@@ -1,0 +1,10 @@
+(defsystem "gossip-config-tests"
+  :defsystem-depends-on (prove-asdf)
+  :depends-on (gossip/config
+               prove
+               alexandria)
+  :perform (test-op (o s)
+              (symbol-call :prove :run s))
+  :components ((:test-file "generate-network")))
+
+  

--- a/src/gossip/gossip.asd
+++ b/src/gossip/gossip.asd
@@ -34,6 +34,7 @@
   :depends-on (emotiq/filesystem
                emotiq/logging
                crypto-pairings)
+    :in-order-to ((test-op (test-op "gossip-config-tests")))
   :components ((:module package :pathname "."
                         :components ((:file "package")))
                (:module config :pathname "config/"

--- a/src/gossip/gossip.asd
+++ b/src/gossip/gossip.asd
@@ -2,7 +2,7 @@
   :name "Gossip"
   :description "Gossip protocols"
   :author "Shannon Spires <svs@emotiq.ch>"
-  :version "0.2.2"
+  :version "0.2.3"
   :maintainer "Shannon Spires <svs@emotiq.ch>"
   :depends-on (gossip/config
                emotiq/logging
@@ -32,6 +32,7 @@
 
 (defsystem "gossip/config"
   :depends-on (emotiq/filesystem
+               emotiq/logging
                crypto-pairings)
   :components ((:module package :pathname "."
                         :components ((:file "package")))


### PR DESCRIPTION
Fixes

```
Getting following:

emotiq@emq01:~/tmp$ ./generate-host-configurations.bash nodes.conf ~/tmp/conf
To load "gossip/config":
  Load 1 ASDF system:
    gossip/config
; Loading "gossip/config"
.
> Error: Undefined function EMOTIQ:NOTE called with arguments ("~&Writing configuration to '~a'.~&" #P"/home/emotiq/tmp/emq01-link0/conf") .
> While executing: GOSSIP/CONFIG:GENERATE, in process listener(1).
> Type :GO to continue, :POP to abort, :R for a list of available restarts.
> If continued: Retry applying EMOTIQ:NOTE to ("~&Writing configuration to '~a'.~&" #P"/home/emotiq/tmp/emq01-link0/conf").
> Type :? for other options.
1 > 

```