### PR TITLE
Remove actor-based atomicity from hmac-keypair since it's designed wrong

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   LWPRO_MACOS_64: lwpro
   lisp: lisp-wrapper.sh
 # Add ASDF systems here to test them
-  systems: ":cosi-bls-tests :crypto-pairings :gossip-tests :emotiq/wallet"
+  systems: ":cosi-bls-tests :crypto-pairings :gossip-tests :emotiq/wallet :gossip-config-tests"
 
 stages:
   - test

--- a/etc/build-crypto-pairings.bash
+++ b/etc/build-crypto-pairings.bash
@@ -13,6 +13,8 @@
 # debug
 set -x
 
+EXTERNAL_LIBS_VERSION=release-0.1.8
+
 DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 BASE=${DIR}/..
@@ -24,6 +26,9 @@ case ${uname_s} in
         echo Building for Linux
         lib_suffix=linux
         maketarget=makefile.linux
+        if [ "x${PENTIUM4}" == "xtrue" ] ; then
+          EXTERNAL_LIBS_VERSION=release-0.1.8-p4-linux
+        fi
         ;;
     Darwin*)
         echo Building for macOS
@@ -36,8 +41,6 @@ case ${uname_s} in
         exit 127
         ;;
 esac
-
-EXTERNAL_LIBS_VERSION=release-0.1.2
 
 libs_url=https://github.com/emotiq/emotiq-external-libs/releases/download/${EXTERNAL_LIBS_VERSION}/emotiq-external-libs-${lib_suffix}.tgz
 

--- a/src/gossip/config/generate.lisp
+++ b/src/gossip/config/generate.lisp
@@ -8,25 +8,27 @@
 (defun generate (records &key (root #p"/var/tmp/conf/"))
   "Generate configuration directories of an Emotiq testnet for RECORDS at directory ROOT
 
-
 The ROOT defaults to '/var/tmp/conf'."
-  (let ((key-records (generate-keys records)))
+  (let ((key-records (generate-keys records))
+        directories)
     (dolist (key-record key-records)
       (destructuring-bind (host eripa port (public private))
           key-record
         (declare (ignore private))
         (let ((directory (merge-pathnames (format nil "~a/" host) root)))
           (emotiq:note "~&Writing configuration to '~a'.~&" directory)
-             (ensure-directories-exist directory)
-             (write-local-machine-conf
-              (merge-pathnames "local-machine.conf" directory)
-              eripa port public)
-             (write-hosts-conf
-              (merge-pathnames "hosts.conf" directory)
+          (ensure-directories-exist directory)
+          (write-local-machine-conf
+           (merge-pathnames "local-machine.conf" directory)
+           eripa port public)
+          (write-hosts-conf
+           (merge-pathnames "hosts.conf" directory)
            key-records)
-             (write-keypairs-conf
-              (merge-pathnames "keypairs.conf" directory)
-           key-records))))))
+          (write-keypairs-conf
+           (merge-pathnames "keypairs.conf" directory)
+           key-records)
+          (push directory directories))))
+    directories))
 
 (defun generate-keys (records)
   (loop

--- a/src/gossip/config/t/generate-network.lisp
+++ b/src/gossip/config/t/generate-network.lisp
@@ -1,0 +1,42 @@
+(in-package :cl-user)
+
+(prove:plan 1)
+(let ((root #p"/var/tmp/emotiq/gossip/config/")
+      (network
+       `((:hostname "emq-01.aws.emotiq.ch"
+                    :ip "34.239.111.18"
+                    :port 65002)
+         (:hostname "emq-02.aws.emotiq.ch"
+                    :ip "52.12.224.84"
+                    :port 8080)
+         (:hostname "emq-02.aws.emotiq.ch"
+                    :ip "52.54.123.84"
+                    :port 65001)
+         (:hostname "emq-03.aws.emotiq.ch"
+                    :ip "52.54.224.84"
+                    :port 443)
+         (:hostname "emq-05.aws.emotiq.ch"
+                    :ip "34.217.39.58"
+                    :port 22))))
+  (ensure-directories-exist root)
+  (prove:ok (gossip/config:generate network :root root)
+            (format nil "Generating test network configuration in~&~t~a~& for ~&~s~&…"
+                    root network))
+  (let* ((hostname
+          (getf (alexandria:random-elt gossip/config:*aws-example*)
+                :hostname))
+         (p
+          (make-pathname
+           :directory `(,@(pathname-directory root) ,hostname)
+           :defaults root)))
+    (prove:plan 1)
+    (prove:ok (probe-file p)
+              (format nil "Generated configuration directory '~a' exists…"
+                      p))))
+;;; FIXME: remove directory from filesystem
+
+(prove:finalize)
+
+
+
+   

--- a/src/gossip/config/t/gossip-config-tests.asd
+++ b/src/gossip/config/t/gossip-config-tests.asd
@@ -1,0 +1,10 @@
+(defsystem "gossip-config-tests"
+  :defsystem-depends-on (prove-asdf)
+  :depends-on (gossip/config
+               prove
+               alexandria)
+  :perform (test-op (o s)
+              (symbol-call :prove :run s))
+  :components ((:test-file "generate-network")))
+
+  

--- a/src/gossip/gossip.asd
+++ b/src/gossip/gossip.asd
@@ -2,7 +2,7 @@
   :name "Gossip"
   :description "Gossip protocols"
   :author "Shannon Spires <svs@emotiq.ch>"
-  :version "0.2.2"
+  :version "0.2.3"
   :maintainer "Shannon Spires <svs@emotiq.ch>"
   :depends-on (gossip/config
                emotiq/logging
@@ -31,7 +31,9 @@
 
 (defsystem "gossip/config"
   :depends-on (emotiq/filesystem
+               emotiq/logging
                crypto-pairings)
+    :in-order-to ((test-op (test-op "gossip-config-tests")))
   :components ((:module package :pathname "."
                         :components ((:file "package")))
                (:module config :pathname "config/"

--- a/src/gossip/gossip.lisp
+++ b/src/gossip/gossip.lisp
@@ -1997,11 +1997,11 @@ gets sent back, and everything will be copacetic.
 
 (defun transport-peer-up (peer-address peer-port)
   "Callback for transport layer event."
-  (log-event "Transport connection to peer established" peer-address peer-port))
+  (log-event :TRANSPORT "Transport connection to peer established" peer-address peer-port))
 
 (defun transport-peer-down (peer-address peer-port reason)
   "Callback for transport layer event."
-  (log-event "Transport connection to peer failed" peer-address peer-port reason))
+  (log-event :TRANSPORT "Transport connection to peer failed" peer-address peer-port reason))
 
 (defun shutdown-gossip-server ()
   "Stop the Gossip Transport network endpoint (if currently running)."
@@ -2026,11 +2026,16 @@ gets sent back, and everything will be copacetic.
       (setf *hmac-keypair* (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid)))))
     (actor-send mbox *hmac-keypair*)))
 
+#+IGNORE
 (defun hmac-keypair ()
   (or *hmac-keypair*
       (let ((mbox (mpcompat:make-mailbox)))
         (actor-send *hmac-keypair-actor* :TAS mbox)
         (first (mpcompat:mailbox-read mbox)))))
+
+(defun hmac-keypair ()
+  (or *hmac-keypair*
+      (setf *hmac-keypair* (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid))))))
 
 (defun sign-message (msg)
   "Sign and return an authenticated message packet. Packet includes

--- a/src/gossip/gossip.lisp
+++ b/src/gossip/gossip.lisp
@@ -2042,11 +2042,12 @@ gets sent back, and everything will be copacetic.
 (defun sign-message (msg)
   "Sign and return an authenticated message packet. Packet includes
   original message."
-  (assert (pbc:check-public-key (pbc:keying-triple-pkey (hmac-keypair))
-                                (pbc:keying-triple-sig  (hmac-keypair))))
-  (pbc:sign-message msg
-                    (pbc:keying-triple-pkey (hmac-keypair))
-                    (pbc:keying-triple-skey (hmac-keypair))))
+  (let ((keypair (hmac-keypair)))
+    (assert (pbc:check-public-key (pbc:keying-triple-pkey keypair)
+                                  (pbc:keying-triple-sig  keypair)))
+    (pbc:sign-message msg
+                      (pbc:keying-triple-pkey keypair)
+                      (pbc:keying-triple-skey keypair))))
 
 ;; ------------------------------------------------------------------------------
 


### PR DESCRIPTION
(see https://github.com/emotiq/research/wiki/A-Danger-with-Actors) and
it's no longer necessary since we're initializing PBC correctly now.