### PR TITLE
Finishing spend transactions - verify transactions on nodes

### DIFF
--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -223,7 +223,8 @@
    dump-tx
    dump-txs
    clear-transactions-in-block-from-mempool
-   txid-string))
+   txid-string
+   wait-for-tx-count))
 
 ;; from cosi-construction
 (defpackage :cosi-simgen

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -338,7 +338,20 @@ This will spawn an actor which will asynchronously do the following:
 
             ;; Dump the whole blockchain now after about a minute,
             ;; just before exiting:
-            (sleep 60)
+            (multiple-value-bind (all-done-p elapsed-seconds-if-done)
+                (cosi/proofs/newtx:wait-for-tx-count 4 :timeout 60)
+              (cond
+                (all-done-p
+                 (format t "~%Finished ~d transactions in ~d second~p~%"
+                         4 elapsed-seconds-if-done elapsed-seconds-if-done))
+                (t
+                 (cerror
+                  "Continue regardless."
+                  "Timed out, waited 60 sec for 4 transactions on blockchain."))))
+            ;; previous:
+            ;; (sleep 60)
+
+            
             (format t "~3%Here's a dump of the whole blockchain currently:~%")
             (cosi/proofs/newtx:dump-txs :blockchain t)
             (format t "~2%Good-bye and good luck!~%"))))))


### PR DESCRIPTION
 - verify transactions on nodes (check merkle root against recomputed
   merkle tree on each non-leader node). Now check-block-transactions
   does the checking and has documentation as to its purpose.

 - in addition, this commit adds the beginnings of generality for
   other types of transactions besides uncloaked spend transactions:
   first other type we'll use will be collect, and the next on after
   that will be cloaked spend. (Note that these are just no-op
   transformations that add some flexibility but should not end up
   changing any functionality as of yet.)

 - debugging improvement: added wait-for-tx-count and use in node-sim:
   this lets us sleep for the minimal amount of time waiting for the 4
   transactions to complete while showing "ticks" every second, an
   improvement over simply going to sleep for 60 seconds
   unconditionally.