### PR TITLE
changes for fees and collect transaction, with other cleanups, fixes

### DIFF
--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -137,7 +137,7 @@ added to the blockchain."
 ;;; block is created and cannot be changed. The order is somewhat flexible
 ;;; except for the following partial ordering constraints:
 ;;;
-;;;   (1) a coinbase transaction must come first; and
+;;;   (1) a collect transaction must come first; and
 ;;;
 ;;;   (2) for any two transactions Tx1, Tx2, if the input of Tx2 spends the
 ;;;   output of Tx1, Tx1 must come before Tx2.

--- a/src/Cosi-BLS/new-transactions.lisp
+++ b/src/Cosi-BLS/new-transactions.lisp
@@ -50,6 +50,7 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
 ;;;   :spend -- for an uncloaked spend transaction
 ;;;   :spend-cloaked -- for a cloaked spend transaction
 ;;;   :collect -- for a collect transaction
+;;;   :coinbase -- for the (one) transaction that creates coin (a/k/a the genesis transaction)
 
 
 
@@ -585,7 +586,7 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
                             (- sum-of-inputs sum-of-outputs)
                             *minimum-transaction-fee*)
                       (return nil))
-                    (emotiq:note "~%Node ~a declares Successful transaction ~a~%  TxID = ~a~%"
+                    (emotiq:note "~%Node ~a declares successful transaction ~a~%  TxID = ~a~%"
                                  (cosi-simgen:current-node)
                                  transaction
                                  (txid-string (transaction-id transaction)))
@@ -857,18 +858,6 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
 
 
 
-(defparameter *coinbase-fee-in-coin-units* (/ 5 8)
-  "The default coinbase fee. This is the amount awarded to the creator of each
-  new ledger block.  This can be set to either an integer, float, or ratio. Use
-  function get-coinbase-transaction-fee-amount to scale and round this to get it
-  as a coin amount.")
-
-(defun get-coinbase-transaction-fee-amount ()
-  (coin-amount *coinbase-fee-in-coin-units*))
-
-
-
-
 ;;; The next two values to initialize the id and index of the input for a coinbase transaction
 ;;; are settings are imitative of Bitcoin, which similarly has
 ;;; all 0 bits for Tx ID, all 1 bits for Tx index. These slots do not serve
@@ -911,20 +900,12 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
 
 
 (defun make-genesis-transaction (public-key-hash)
-  (make-and-maybe-sign-transaction
+  (make-transaction
    (list (make-coinbase-transaction-input))
    (list (make-coinbase-transaction-output
           public-key-hash 
-          (initial-total-coin-amount)))))
-
-
-
-(defun make-coinbase-transaction (public-key-hash)
-  (make-and-maybe-sign-transaction
-   (list (make-coinbase-transaction-input))
-   (list (make-coinbase-transaction-output
-          public-key-hash
-          (get-coinbase-transaction-fee-amount)))))
+          (initial-total-coin-amount)))
+   ':coinbase))
 
 
 
@@ -1180,7 +1161,7 @@ returns the block the transaction was found in as a second value."
 (defun map-transaction-type-to-unlock-script (transaction-type)
   (get-unlocking-script 
    (ecase transaction-type
-     ((:spend :spend-cloaked :collect) 
+     ((:spend :spend-cloaked :collect :coinbase)
       'script-sig))))
   
 
@@ -1201,9 +1182,11 @@ returns the block the transaction was found in as a second value."
 (defun map-transaction-type-to-lock-script (transaction-type)
   (get-locking-script 
    (ecase transaction-type
-     (:spend 'script-pub-key)
-     (:spend-cloaked 'script-pub-key-cloaked)
-     (:spend-cloaked 'script-collect))))
+     ((:spend :collect :coinbase) 'script-pub-key)
+     (:spend-cloaked 'script-pub-key-cloaked))))
+
+;; ---*** note: per David we must ultimately make the :coinbase
+;; ---*** transaction cloaked. Review later!  -mhd, 6/26/18
 
 
 (defun check-private-keys-for-transaction-inputs (private-keys tx-inputs)
@@ -1225,14 +1208,16 @@ returns the block the transaction was found in as a second value."
      (length tx-inputs))))
 
 
-(defun make-and-maybe-sign-transaction (tx-inputs tx-outputs &key skeys pkeys)
+(defun make-and-maybe-sign-transaction (tx-inputs tx-outputs &key skeys pkeys (type :spend))
   "Create a transaction. Then, if keyword keys is provided non-nil,
 the transaction is signed. In the signing case, keys should supply one
 private key for each input, either as a single private atomic private
 key or singleton list in the case of a single input or as a list of
 keys in the case of two or more inputs. Normally, all transactions
-should be signed, and only coinbase transactions are not signed."
-  (let* ((transaction (make-transaction tx-inputs tx-outputs)))
+should be signed, and only coinbase transactions are not
+signed. Keyword TYPE, if provided, should a transaction type keyword,
+or else it defaults to :SPEND for an uncloaked spend transaction."
+  (let* ((transaction (make-transaction tx-inputs tx-outputs type)))
     ;; Got keys? Sign transaction if so:
     (when skeys
       (sign-transaction transaction skeys pkeys))
@@ -1240,10 +1225,12 @@ should be signed, and only coinbase transactions are not signed."
 
 
 
-(defun make-transaction (tx-inputs tx-outputs)
-  "Create a transaction with inputs TX-INPUTS and outpus TX-OUTPUTS."
+(defun make-transaction (tx-inputs tx-outputs type)
+  "Create a transaction with inputs TX-INPUTS, outputs TX-OUTPUTS, and
+of type TYPE."
   (make-instance
    'transaction
+   :transaction-type type
    :transaction-inputs tx-inputs
    :transaction-outputs tx-outputs))
 
@@ -1345,8 +1332,12 @@ ADDRESS here is taken to mean the same thing as the public key hash."
 
 
 (defun dump-tx (tx &key out-only)
+  (unless (eq (transaction-type tx) ':spend)
+    (format t "~&  ~a Transaction~%" (transaction-type tx)))
   (format t "~&  TxID: ~a~%" (txid-string (transaction-id tx)))
-  (unless out-only
+  (unless (or out-only
+              (member (transaction-type tx)
+                      '(:coinbase :collect))) ; no-input tx types
     (loop for tx-in in (transaction-inputs tx)
           do (format t "    input outpoint: index = ~a/TxID = ~a~%"
                      (tx-in-index tx-in) (txid-string (tx-in-id tx-in)))))
@@ -1389,35 +1380,42 @@ ADDRESS here is taken to mean the same thing as the public key hash."
 
 (defparameter *wait-for-tx-count-tick-print* ".")
 (defparameter *wait-for-tx-count-tick-every* 10)
-(defparameter *wait-for-tx-count-message* "Waiting for tx count: ")
+(defparameter *wait-for-tx-default-tx-types* '(:spend :spend-cloaked))
 
-(defun wait-for-tx-count (n &key interval timeout node
-                                 tick-print tick-every message)
+(defun spend-tx-types-p (tx-types)
+  (equal '#.(sort (copy-list '(:spend :spend-cloaked)) #'string<)
+         (sort (copy-list tx-types) #'string<)))
+
+(defun wait-for-tx-count (n &key interval timeout node tx-types
+                                 tick-print tick-every)
   "Alternate sleeping for a small INTERVAL while waiting for there to
-   have been a total of N transaction on the blockchain. INTERVAL
-   defaults to about 1/10th of a second, and a user-specified value is
-   restricted to a reasonable range > 0 and <= 1 second.  The
-   blockchain is with respect to NODE, which can be a specified node,
-   and otherwise defaults to the current node, if non-nil, and
-   otherwise the top node. A timeout occurs when TIMEOUT, which
-   defaults to nil, has been supplied non-nil, in which case it should
-   ben an interval in seconds. Then, when that amount of time has
-   elapsed, a timeout has been reached, and the function returns.  If
-   the count is reached, this returns true; if a timeout occurs, this
-   returns nil; otherwise, this does not return, and simply continues
-   alternating between checking the count of transactions and sleeping
-   for brief intervals."
+   have been a total of N spend transactions (or possibly other types
+   if TX-TYPES is specified) on the blockchain. INTERVAL defaults to
+   about 1/10th of a second, and a user-specified value is restricted
+   to a reasonable range > 0 and <= 1 second.  The blockchain is with
+   respect to NODE, which can be a specified node, and otherwise
+   defaults to the current node, if non-nil, and otherwise the top
+   node. A timeout occurs when TIMEOUT, which defaults to nil, has
+   been supplied non-nil, in which case it should ben an interval in
+   seconds. Then, when that amount of time has elapsed, a timeout has
+   been reached, and the function returns.  If the count is reached,
+   this returns true; if a timeout occurs, this returns nil;
+   otherwise, this does not return, and simply continues alternating
+   between checking the count of transactions and sleeping for brief
+   intervals. If TX-TYPES is specified, it should be a list of
+   transaction types to wait for; otherwise, it defaults to spend
+   transactions, both cloaked and uncloaked."
   (when interval
     (setq interval (max 1 (min 1/1000 interval))))
   (setq tick-print
         (or tick-print
             *wait-for-tx-count-tick-print*))
-  (setq message
-        (or message
-            *wait-for-tx-count-message*))
   (setq tick-every
         (or tick-every
             *wait-for-tx-count-tick-every*))
+  (setq tx-types
+        (or tx-types 
+            *wait-for-tx-default-tx-types*))
   (loop with start-ut = (get-universal-time)
         with interval = (or interval 1/10)
         with cosi-simgen:*current-node*
@@ -1427,12 +1425,16 @@ ADDRESS here is taken to mean the same thing as the public key hash."
         as count                        ; see note!
           = (let ((count-so-far 0))
               (do-all-transactions (tx)
-                tx                   ; (ignored, just to gag compiler)
-                (incf count-so-far))
+                (when (member (transaction-type tx) tx-types)
+                  (incf count-so-far)))
               count-so-far)
         as time-through from 0
         initially
-           (format t "~%~a~d" message n)
+           (format t "~%Awaiting ~d ~a txs.~%"
+                   n                   
+                   (if (spend-tx-types-p tx-types) 
+                       "spend"
+                       (format nil "[transaction types = ~s]" tx-types)))
         when (>= count n)
           return (values t (- (get-universal-time) start-ut))
         when (and timeout
@@ -1481,9 +1483,17 @@ ADDRESS here is taken to mean the same thing as the public key hash."
                      while (> tx-count max)
                      do (decf tx-count))
                (setq transactions (nreverse rev-txs))))
-           #+development (assert (= (length transactions) tx-count))
-           (ac:pr (format nil "~D Transactions" tx-count))
-           (return transactions)))  
+           ;; #+development (assert (= (length transactions) tx-count))
+           (emotiq:note "~D Transactions for new block" tx-count)
+           ;; Now, compute the fees, and add a collect transaction,
+           ;; which must precede all the other transactions.
+           (let* ((total-fee
+                    (loop for tx in transactions
+                          sum (compute-transaction-fee tx)))
+                  (collect-transaction
+                    (make-collect-transaction total-fee)))
+             (push collect-transaction transactions))
+           (return transactions)))
 
 ;; Note: new transactions currently do not use UTXO database, only
 ;; mempool and blockchain.
@@ -1508,7 +1518,65 @@ ADDRESS here is taken to mean the same thing as the public key hash."
 
 
 
-(defun check-block-transactions (blk)  
+
+(defun make-collect-transaction (fee)
+  "Make a collect transaction with amount equal to FEE, an amount of
+   tokens to transfer. The fee is designated to be paid to the address
+   (a function of the public key) of the leader node."
+  (let* ((leader-public-key cosi-simgen:*leader*)
+         (leader-address
+           (cosi/proofs:public-key-to-address leader-public-key)))
+    (make-transaction
+     (list (make-coinbase-transaction-input))
+     (list (make-coinbase-transaction-output leader-address fee))
+     ':collect)))
+
+;; The "coinbase" terminilogy, and some early implementation
+;; approaches, spills over here for now, interfering with our
+;; "collect" terminology and approach. It's minimal, but should
+;; eventually be cleaned up! -mhd, 6/26/18
+    
+  
+
+
+
+
+
+(defun compute-transaction-fee (transaction)
+  "Compute the transaction fee on TRANSACTION, a transaction instance
+   that has been fully validated and comes from the mempool, and this
+   therefore makes all the assumptions as to validations, such as UTXO
+   exists, no double spends, valid amounts, etc. The fee is computed
+   as the sum of the inputs minus the sum of the outputs.  In our
+   blockchain system the leader node creates a so-called collect
+   transaction as the first transaction of every block, except the
+   genesis, and directs that it be sent to an address of their
+   choosing."
+  (loop for tx-in in (transaction-inputs transaction)
+        as id = (tx-in-id tx-in)
+        as index = (tx-in-index tx-in)
+        as input-tx = (find-transaction-per-id id t)
+        as input-tx-outputs 
+          = (if (null input-tx)
+                (error "no match TxID = ~a" (txid-string id)) 
+                (transaction-outputs input-tx))
+        as utxo
+          = (or (nth index input-tx-outputs)
+                (error "no match index = ~a" index))
+        as input-subamount = (tx-out-amount utxo)
+        sum input-subamount into sum-of-inputs
+        finally (let* ((sum-of-outputs
+                         (loop for tx-out in (transaction-outputs transaction)
+                               sum (tx-out-amount tx-out)))
+                       (fee (- sum-of-inputs sum-of-outputs)))
+                  ;; #+development
+                  (when (< fee 0)       ; error if it happens here
+                    (error "Negative fee: ~a! sum of inputs (~a) < sum of outputs (~a)."
+                           fee sum-of-inputs sum-of-outputs))
+                  (return fee))))
+
+
+(defun check-block-transactions (blk)
   "Return nil if invalid block. This is run by a CoSi block 
    validator. Validate by recomputing the full merkle hash on all the 
    transactions and comparing with that with that saved in the 

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -244,7 +244,8 @@ This will spawn an actor which will asynchronously do the following:
                (cosi/proofs/newtx:make-and-maybe-sign-transaction
                 transaction-inputs transaction-outputs
                 :skeys (pbc:keying-triple-skey *genesis-account*)
-                :pkeys (pbc:keying-triple-pkey *genesis-account*))))
+                :pkeys (pbc:keying-triple-pkey *genesis-account*)
+                :type :spend)))
         (setq *tx-1* signed-transaction)
         (ac:pr (format nil "Broadcasting 1st TX."))
         (format t "~%Tx 1 created/signed by genesis (~a), now broadcasting."
@@ -326,7 +327,8 @@ This will spawn an actor which will asynchronously do the following:
                   (cosi/proofs/newtx:make-and-maybe-sign-transaction
                    transaction-inputs transaction-outputs
                    :skeys (pbc:keying-triple-skey *user-2*)
-                   :pkeys (pbc:keying-triple-pkey *user-2*)))
+                   :pkeys (pbc:keying-triple-pkey *user-2*)
+                   :type ':spend))
 
             (ac:pr (format nil "Broadcasting 5th TX [attempt to double-spend (diff TxID)]."))
             (format t "~%Tx 5 created/signed by user-2 (~a) [attempt to double-spend (diff TxID)], now broadcasting."
@@ -339,11 +341,11 @@ This will spawn an actor which will asynchronously do the following:
             ;; Dump the whole blockchain now after about a minute,
             ;; just before exiting:
             (multiple-value-bind (all-done-p elapsed-seconds-if-done)
-                (cosi/proofs/newtx:wait-for-tx-count 4 :timeout 60)
+               (cosi/proofs/newtx:wait-for-tx-count 3 :timeout 60)
               (cond
                 (all-done-p
-                 (format t "~%Finished ~d transactions in ~d second~p~%"
-                         4 elapsed-seconds-if-done elapsed-seconds-if-done))
+                 (format t "~%Finished ~d spend transactions in ~d second~p~%"
+                         3 elapsed-seconds-if-done elapsed-seconds-if-done))
                 (t
                  (cerror
                   "Continue regardless."


### PR DESCRIPTION
Working collect transactions, as well as cleanup of several other things.

Code to support making new collect type transactions, including code
to compute the fee on a transaction.

Made up a new type for the initial coinbase transaction in the genesis
block: :coinbase

Improved code to dump transactions, leaving out the useless
pseudo/dummy inputs in the case of collect and coinbase
transactions, and noting the transaction type in the case of
unusual, i.e., non-spend type, transaction.

Wait-for-tx-count, used by demo/test code in node-sim, had
various changes in response to the new types of transactions. Now
it counts only spend transactions by default. There's an option
to override/specify which types of transaction are counted.

The node-sim file's run-new-tx demo now advises that it's waiting
for 3 spend transactions, and then that it has finished 3 spend
transactions.  At the end, the dumper shows all the types of
transactions.  The dumper now identifies specially any
transaction that is not of type :spend, which is the most common,
standard, and default type.