### PR TITLE
Fix compiler warnings only CCL gives you (or that LispWorks does not).

### DIFF
--- a/src/Crypto/curve-gen.lisp
+++ b/src/Crypto/curve-gen.lisp
@@ -41,6 +41,8 @@ THE SOFTWARE.
 #+:LISPWORKS
 (editor:setup-indent "with-repl-fn" 1)
 
+(defstub ecc-affine-sub)
+
 (defun do-with-lisp-ecc (fn)
   (with-repl-fn (ecc-basic-mul #'ecc-projective-mul)
     (with-repl-fn (ecc-add #'ecc-affine-add)

--- a/src/Crypto/utilities.lisp
+++ b/src/Crypto/utilities.lisp
@@ -511,6 +511,9 @@ from calling the function."
             (setf (aref ans ix)
                   (fli:dereference carr :index ix)))
       ans)))
+
+#-:LISPWORKS
+(defstub fast-sha2-file)
   
 
 (defun sha2-file (fname)
@@ -535,6 +538,9 @@ from calling the function."
             (setf (aref ans ix)
                   (fli:dereference carr :index ix)))
       ans)))
+
+#-:LISPWORKS
+(defstub fast-shad2-file)
   
 (defun shad2-file (fname)
   (with-fast-impl

--- a/src/useful-macros/useful-macros.lisp
+++ b/src/useful-macros/useful-macros.lisp
@@ -1523,6 +1523,9 @@ THE SOFTWARE.
   (apply #'where-if (curry test item) seq keys))
 
 
+(defun nthcar (n list) 
+  (car (nthcdr n list)))
+
 (defmethod subselect ((lst list) where-lst)
   ;; not very efficient on lists... use subselect-if on lists
   (mapcar (rcurry #'nthcar lst) where-lst))


### PR DESCRIPTION
Two categories of warnings:

- Apparently, LispWorks does not complain about funcall or apply of an
  undefined function. E.g., try this, and CCL (and other Lisps, e.g.,
  SBCL) would squawk, but not LW:

    (defun foo (list) (mapcar #'unknown-fn list))

  This accounts for the lack of warnings for function ecc-affine-sub
  in src/Crypto/curve-gen.lisp and function nthcar in
  src/useful-macros/useful-macros.lisp. For the later, I just defined
  the function in the way implied by its name, and by what would work
  to match the functionality of the vector version of the calling
  defgeneric.  For the former, it seemed this must not be used or
  needed, so I just defined a stub using defstub.

- There were a couple of LispWorks-only definitions:

    fast-shad2-file and fast-sha2-file

  So for non-Lispworks I defined stubs using defstub.