### PR TITLE
New block slots for merkle roots and witness/stakes, cleanups continue.

### DIFF
--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -1004,8 +1004,7 @@ check that each TXIN and TXOUT is mathematically sound."
 
 (defun check-block-transactions-hash (blk)
   (hash= (block-merkle-root-hash blk) ;; check transaction hash against header
-         (compute-merkle-root-hash
-          (block-transactions blk))))
+         (compute-merkle-root-hash blk)))
 
 (defmethod add-pkeys ((pkey1 null) pkey2)
   pkey2)

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -180,6 +180,8 @@
    :serialize-block-octets
    :serialize-block-header-octets
    :compute-merkle-root-hash
+   :compute-input-script-merkle-root-hash
+   :compute-witness-merkle-root-hash
 
    :ith-witness-signed-p
    :set-ith-witness-signed-p
@@ -195,6 +197,15 @@
    :block-signature-pkey
    :block-signature
    :block-merkle-root-hash
+   :block-input-script-merkle-root-hash
+   :block-witness-merkle-root-hash
+
+   :utxo-p
+   :get-utxos-per-account
+   :get-balance
+
+   :to-txid
+   :find-tx
 
    :*newtx-p*))                         ; for new transactions, short term temp! -mhd, 6/12/18
 
@@ -224,7 +235,10 @@
    dump-txs
    clear-transactions-in-block-from-mempool
    txid-string
-   wait-for-tx-count))
+   wait-for-tx-count
+   hash-transaction-id
+   hash-transaction-input-scripts-id
+   hash-transaction-witness-id))
 
 ;; from cosi-construction
 (defpackage :cosi-simgen


### PR DESCRIPTION
- added a slot to eblock class for a table (a-list) giving
  corresponding node public keys their stake amounts

- merkleize witness data and input scripts: added slots to eblock
  class for new merkle root hashes for witness data, and added these
  hashes to block creation, and added checks in block validation on
  non-leader nodes

- get rid of transaction contexts, an idea whose time came and went

- document and use more of account-addresses= for addresses (public
  key hashes)

- clean up doc on tx-ids=

- clean up doc on do-transactions

- wallet API fixups:
  - fix and change UTXO-P to make sense and document it reasonably
  - get-balance now works; fix up its doc, add a useful second value
  - package exports: utxo-p, get-utxos-per-account, get-balance

- add some convenience debug/repl util functions to-txid, find-tx
  - package exports: to-txid, find-tx