### PR TITLE
Create-genesis-block takes witnesses-and-stakes.

### DIFF
--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -199,6 +199,7 @@
    :block-merkle-root-hash
    :block-input-script-merkle-root-hash
    :block-witness-merkle-root-hash
+   :block-witnesses-and-stakes
 
    :*newtx-p*))                         ; for new transactions, short term temp! -mhd, 6/12/18
 

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -215,7 +215,8 @@ This will spawn an actor which will asynchronously do the following:
                ;; Establish current-node binding of genesis node
                ;; around call to create genesis block.
                (cosi/proofs:create-genesis-block
-                (pbc:keying-triple-pkey *genesis-account*))))
+                (pbc:keying-triple-pkey *genesis-account*)
+                (keys-and-stakes))))
            (genesis-transaction         ; kludgey handling here
              (first (cosi/proofs:block-transactions genesis-block)))
            (genesis-public-key-hash


### PR DESCRIPTION
Stored on block-witnesses-and-stakes slot of etable.
Block-witnesses-and-stakes-table renamed block-witnesses-and-stakes.
Symbol block-witnesses-and-stakes now exported from cosi/proofs.