### PR TITLE
Fixes for EMOTIQ/CONFIG:ENSURE-DEFAULTS

### DIFF
--- a/src/Cosi-BLS/cosi-bls.asd
+++ b/src/Cosi-BLS/cosi-bls.asd
@@ -31,6 +31,7 @@ THE SOFTWARE.
   :depends-on (emotiq/logging
                ironclad
                actors
+               emotiq/config/stakes
                core-crypto
                crypto-pairings
                lisp-object-encoder

--- a/src/Cosi-BLS/cosi.asd
+++ b/src/Cosi-BLS/cosi.asd
@@ -1,0 +1,80 @@
+(defsystem cosi
+  :depends-on nil)
+
+(defsystem cosi/package
+  :depends-on (actors
+               core-crypto
+               ads-clos
+               crypto-pairings
+               emotiq/logging
+               ironclad
+               lisp-object-encoder
+               useful-macros
+               usocket
+               trivial-garbage
+               gossip)
+  :components ((:module package
+                        :pathname "./"
+                        :components ((:file "package")))))
+
+(defsystem cosi/bls/dependencies
+  :depends-on (actors
+               core-crypto
+               ads-clos
+               crypto-pairings
+               emotiq/logging
+               ironclad
+               lisp-object-encoder
+               useful-macros
+               usocket
+               trivial-garbage
+               gossip)
+  :components nil)
+
+(defsystem cosi/bls
+  :depends-on (cosi/package
+               cosi/bls/dependencies)
+  :components (#+ccl
+               (:module clozure
+                        :pathname "./"
+                        :components ((:file "clozure")))
+               (:module source
+                        :pathname "./"
+                        :components ((:file "cosi-blkdef")
+                                     (:file "cosi-keying")
+                                     (:file "cosi-netw-xlat")))))
+
+(defsystem cosi/simgen
+  :depends-on (cosi/package
+               cosi/proofs
+               cosi/transactions
+               cosi/proofs/newtx
+               emotiq/config/stakes)
+  :components ((:file "cosi-construction")
+               (:file "cosi-handlers")
+               (:file "mvp-election-beacon")))
+
+(defsystem cosi/transactions
+  :depends-on (cosi/bls
+               cosi/proofs/range)
+  :components ((:file "transaction")))
+
+
+(defsystem cosi/proofs/range
+  :depends-on (cosi/package)
+  :components ((:file "range-proofs")))
+
+
+(defsystem cosi/proofs
+  :depends-on (cosi/package)
+  :components ((:file "address")
+               (:file "block")))
+
+(defsystem cosi/proofs/newtx
+  :depends-on (cosi/proofs)
+  :components ((:file "new-transactions")))
+
+
+
+
+

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -33,15 +33,18 @@ THE SOFTWARE.
 
 (defvar *all-nodes*  nil) 
 
-(defun set-nodes (node-list)
-  "NODE-LIST is a list of (public-key stake-amount) pairs"
-  (ac:pr (format nil "election set-nodes ~A" node-list))
-  (assert node-list)
-  (setf *all-nodes* (mapcar (lambda (pair)
-                              (destructuring-bind (pkey stake) pair
-                                (list (pbc:public-key pkey)
-                                      stake)))
-                            node-list)))
+(defun set-nodes (node-alist)
+  "NODE-ALIST is an alist of (public-key . stake-amount) pairs"
+  (ac:pr (format nil "election set-nodes ~A" node-alist))
+  (if node-alist 
+      (setf *all-nodes* (mapcar (lambda (pair)
+                                  (destructuring-bind (pkey . stake) pair
+                                    (list (pbc:public-key pkey)
+                                          stake)))
+                                node-alist))
+      (progn
+        (emotiq:note "Ignoring call to set nodes with no members")
+        nil)))
 
 (defun get-witness-list ()
   *all-nodes*)
@@ -292,7 +295,7 @@ based on their relative stake"
       ;; *local-epoch* will also not have
       ;; changed
       (unless (get-witness-list)
-        (set-nodes (gossip:get-stakes))  ;; <<--- THIS NEEDS TO CHANGE TO MARK D's NOTIONS
+        (set-nodes (emotiq/config:get-stakes)) 
         (setf (node-stake node) ;; probably never used elsewhere...
               (second (assoc (node-pkey node) (get-witness-list)
                              :test 'int=))))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -63,7 +63,9 @@
                            (settings-key-value-alist nil))
   "Generate a test network configuration"
   (let* ((nodes (keys/generate nodes-dns-ip))
-         (stakes (stakes/generate nodes))
+         (stakes (stakes/generate (mapcar (lambda (plist)
+                                            (getf plist :public))
+                                          nodes)))
          directories)
     (dolist (node nodes)
       (let ((configuration
@@ -84,6 +86,9 @@
               configuration)
         (push (cons :address-for-coins
                     (getf (first nodes) :public))
+              configuration)
+        (push (cons :stakes
+                    stakes)
               configuration)
         ;;; Override by pushing ahead in alist
         (when settings-key-value-alist
@@ -123,7 +128,7 @@
                      :if-exists :supersede
                      :direction :output)
     (cl-json:encode-json configuration o))
-  (stakes/write key-records
+  (stakes/write (alexandria:assoc-value configuration :stakes)
                 :path (make-pathname :defaults directory
                                      :name "stakes"
                                      :type "conf"))

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -119,7 +119,8 @@
   :depends-on (cl-json
                emotiq/logging
                emotiq/filesystem
-               cosi-bls
+               emotiq/config/genesis
+               emotiq/config/stakes
                lisp-object-encoder
                useful-macros
                gossip/config)
@@ -128,9 +129,21 @@
                 :pathname "./"
                 :serial t
                 :components ((:file "keys")
-                             (:file "stakes")
-                             (:file "genesis")
                              (:file "config")))))
 
+(defsystem "emotiq/config/stakes"
+  :depends-on (emotiq)
+  :components ((:module source
+                        :pathname "./"
+                        :components ((:file "stakes")))))
+
+
+(defsystem "emotiq/config/genesis"
+  :depends-on (cosi/proofs/newtx
+               alexandria
+               lisp-object-encoder)
+  :components ((:module source
+                        :pathname "./"
+                        :components ((:file "genesis")))))
 
 

--- a/src/genesis.lisp
+++ b/src/genesis.lisp
@@ -12,7 +12,7 @@
       (let ((genesis-block
              (cosi/proofs:create-genesis-block
               (alexandria:assoc-value configuration :address-for-coins)
-              (get-stakes))))
+              (alexandria:assoc-value configuration :stakes))))
         (with-open-file (o genesis-block-path
                            :direction :output
                            :if-exists :supersede)

--- a/src/keys.lisp
+++ b/src/keys.lisp
@@ -5,7 +5,7 @@
 
 The keys of the RECORDS plist are interpreted by gossip/config"
   (loop
-     :with key-integers = (make-key-integers)
+     :for key-integers = (make-key-integers) 
      :for record :in records
      :collecting (append record
                          ;;; HACK adapt to gossip/config needs

--- a/src/stakes.lisp
+++ b/src/stakes.lisp
@@ -6,11 +6,15 @@
   (truncate (/ 1E9 1E3))  ;; ratio of total coins to stakers
   "Maximum amount to award a staked entity")
 
-(defun stakes/generate (pubkeys &key (max-stake *max-stake*))
-  "Given a list of PUBKEYS, generate a random stake for each"
-  (mapcar (lambda (pubkey)
-            (list pubkey (random max-stake)))
-          pubkeys))
+(defun stakes/generate (public-keys &key (max-stake *max-stake*))
+  "Given a list of PUBLIC-KEYS, generate a random stake for each
+
+Returns the alist of public key to stake cons cells.
+
+"
+  (mapcar (lambda (pkey)
+            (cons pkey (random max-stake)))
+          public-keys))
 
 (defun stakes/write (records &key path)
   (with-open-file (o path

--- a/src/stakes.lisp
+++ b/src/stakes.lisp
@@ -1,8 +1,10 @@
 (in-package :emotiq/config)
 
 (defparameter *stakes-filename*
-  "stakes.conf")
-(defparameter *max-stake* (truncate 1E6))
+  (make-pathname :name "stakes" :type "conf"))
+(defparameter *max-stake*
+  (truncate (/ 1E9 1E3))  ;; ratio of total coins to stakers
+  "Maximum amount to award a staked entity")
 
 (defun stakes/generate (pubkeys &key (max-stake *max-stake*))
   "Given a list of PUBKEYS, generate a random stake for each"
@@ -20,8 +22,8 @@
       (format o "~s~%" stake))))
 
 (defun get-stakes ()
-  (let ((p (make-pathname :name "stakes" :type "conf"
-                          :defaults (emotiq/fs:etc/))))
+  (let ((p (merge-pathnames *stakes-filename*
+                            (emotiq/fs:etc/))))
     (when (probe-file p)
       (with-open-file (o p
                          :direction :input)

--- a/src/t/mvp.lisp
+++ b/src/t/mvp.lisp
@@ -1,5 +1,16 @@
 (in-package :cl-user)
 
+
+;;; INTERNAL testing 
+(prove:plan 1)
+(let* ((nodes-dns-ip emotiq/config:*dns-ip-zt.emotiq.ch*)
+       (nodes (emotiq/config::keys/generate nodes-dns-ip)))
+  (prove:is (length nodes)
+            3
+            "Node key generation for three nodes…")
+  (prove:diag (format nil "Nodes created as ~%~t~s" nodes)))
+
+;;; EXTERNAL testing
 (prove:plan 1)
 (let ((nodes-dns-ip emotiq/config:*dns-ip-zt.emotiq.ch*))
   (prove:ok
@@ -7,8 +18,8 @@
    (format nil "Generation of zt.emotiq.ch devnet artifacts from~%~&~s…"
            nodes-dns-ip)))
 
+(prove:plan 1)
 (let ((stakes (emotiq/config:get-stakes)))
-  (prove:plan 1)
   (prove:ok stakes
             "GET-STAKES returns something…"))
   


### PR DESCRIPTION
Ensure that distinct keys are generated for stakes

Repackage cosi-bls with ASDF as cosi.asd

Document the stakes a little higher.

Addresses problems referencing EMOTIQ/CONFIG.

Correct PROVE:PLAN join point in test annotations.

Make use of alternate Cosi packaging in <file:src/Cosi-BLS/cosi.asd>
to resolve ASDF dependencies.  TODO: refactor everything that depends
on Cosi?  Too much work for now, just use as is.