### PR TITLE
write abstractions on top of usocket able workaround some usocket bugs

### DIFF
--- a/src/gossip/gossip-startup.lisp
+++ b/src/gossip/gossip-startup.lisp
@@ -14,7 +14,7 @@
 (defun process-eripa-value (ev)
   (setf *eripa* (if (eq :deduce ev)
                     (eripa)
-                    (usocket::host-to-vector-quad ev))))
+                    (host-to-vector-quad ev))))
 
 (defun configure-local-machine (keypairs local-machine)
   "Clear log, make local node(s) and start server"
@@ -86,7 +86,13 @@
                          (gossip/config:get-values)
       (configure-local-machine keypairs local-machine)
       ;; make it easy to call ping-other-machines later
-      (setf *hosts* (remove (usocket::host-to-hbo (eripa)) hosts :key (lambda (host) (usocket::host-to-hbo (car host)))))
+      (setq *hosts*
+            ;; set up *hosts* with the eripa host removed:
+            (loop with eripa-host-hbo = (host-to-hbo (eripa))
+                  for host-pair in hosts
+                  as host-hbo = (host-to-hbo (first host-pair))
+                  when (not (= eripa-host-hbo host-hbo))
+                    collect host-pair))
       (setf *stakes* stakes)
       (emotiq:note "Gossip init finished.")
       (if ping-others


### PR DESCRIPTION
I think this will make everything a little better. It's for the case on MacOS with LispWorks where you have a localhost that gets resolved to an ipv6 address. If 
```
 (comm:get-host-entry "localhost" :fields '(:addresses))
=> (#<COMM:IPV6-ADDRESS ::1 4020187E73> 2130706433)
```
Gossip-startup was getting an error on LispWorks on MacOS.  This makes a bit of a layer on top of those usocket functions, with a workaround. This fixes the error that occurs at startup. However, it apparently only affected my machine per reports so far. But I kind of understand why that's possible now.

The "remove" loop in gossip startup is way simpler and easier for me to understand. Hope Shannon finds it an improvement.