### PR TITLE
Fixup: UM:CONC1 should have been UM:APPEND1 for non-destructive behavior

### DIFF
--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -331,7 +331,7 @@ based on their relative stake"
 
 (defun make-signed-call-for-election-message (pkey epoch skey)
   (let ((skel  (make-call-for-election-message-skeleton pkey epoch)))
-    (um:conc1 skel (pbc:sign-hash (hash/256 skel) skey))))
+    (um:append1 skel (pbc:sign-hash (hash/256 skel) skey))))
 
 (defun validate-call-for-election-message (pkey epoch sig)
   (and (= epoch *local-epoch*)        ;; talking about current epoch? not late arrival?


### PR DESCRIPTION
CONC1 performs an NCONC on a literal - bad news. Should have been APPEND.