### PR TITLE
Fixes for EMOTIQ/CONFIG:ENSURE-DEFAULTS

### DIFF
--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -240,9 +240,10 @@ added to the blockchain."
                 (make-instance 'pbc:public-key :val general-public-key))
         collect `(,public-key . ,stake-info)))
 
-;; Currently, our gossip config system gives us public keys as bignums (function
-;; get-stakes in package gossip), while the simulator (function keys-and-stakes
-;; in package emotiq/sim) supplies them as instances.
+;; Currently, our config system gives us public keys as bignums
+;; (function get-stakes in package gossip), while the simulator
+;; (function keys-and-stakes in package emotiq/sim) supplies them as
+;; instances.
     
              
 

--- a/src/Cosi-BLS/cosi-bls.asd
+++ b/src/Cosi-BLS/cosi-bls.asd
@@ -31,6 +31,7 @@ THE SOFTWARE.
   :depends-on (emotiq/logging
                ironclad
                actors
+               emotiq/config
                core-crypto
                crypto-pairings
                lisp-object-encoder

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -200,7 +200,12 @@ THE SOFTWARE.
 ;; new for Gossip support, and conceptually cleaner...
 (defmethod initialize-instance :around ((node node) &key &allow-other-keys)
   (setf (node-self node) (make-node-dispatcher node))
-  (call-next-method))
+  (call-next-method)
+  (let ((genesis-block (emotiq/config:get-genesis-block)))
+          (push genesis-block (node-blockchain node))
+          (setf (gethash (cosi/proofs:hash-block genesis-block)
+                         (node-blockchain-tbl node))
+                genesis-block)))
 
 ;; --------------------------------------------------------------
 

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -292,7 +292,7 @@ based on their relative stake"
       ;; *local-epoch* will also not have
       ;; changed
       (unless (get-witness-list)
-        (set-nodes (gossip:get-stakes))  ;; <<--- THIS NEEDS TO CHANGE TO MARK D's NOTIONS
+        (set-nodes (emotiq/config:get-stakes))
         (setf (node-stake node) ;; probably never used elsewhere...
               (second (assoc (node-pkey node) (get-witness-list)
                              :test 'int=))))
@@ -331,7 +331,7 @@ based on their relative stake"
 
 (defun make-signed-call-for-election-message (pkey epoch skey)
   (let ((skel  (make-call-for-election-message-skeleton pkey epoch)))
-    (um:conc1 skel (pbc:sign-hash (hash/256 skel) skey))))
+    (um:append1 skel (pbc:sign-hash (hash/256 skel) skey))))
 
 (defun validate-call-for-election-message (pkey epoch sig)
   (and (= epoch *local-epoch*)        ;; talking about current epoch? not late arrival?

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -119,7 +119,6 @@
   :depends-on (cl-json
                emotiq/logging
                emotiq/filesystem
-               cosi-bls
                lisp-object-encoder
                useful-macros
                gossip/config)

--- a/src/genesis.lisp
+++ b/src/genesis.lisp
@@ -1,29 +1,37 @@
 (in-package :emotiq/config)
 
 (defun genesis/create (configuration &key
-                                       root
+                                       (directory (emotiq/fs:tmp/))
                                        (force nil))
-  (let ((genesis-block-path (merge-pathnames
-                             (alexandria:assoc-value configuration
-                                                     :genesis-block-file)
-                             root)))
-    (when (or force
-              (not (probe-file genesis-block-path)))
-      (let ((genesis-block
-             (cosi/proofs:create-genesis-block
-              (alexandria:assoc-value configuration :address-for-coins)
-              (get-stakes))))
-        (with-open-file (o genesis-block-path
-                           :direction :output
-                           :if-exists :supersede)
-          (cl-json:encode-json genesis-block o))
+  (let ((create-genesis-block (uiop:find-symbol* :create-genesis-block :cosi/proofs)))
+    (unless (fboundp create-genesis-block)
+      (warn "COSI-BLS ASDF system not loaded; please load manually before attempting genesis.")
+      (return-from genesis/create nil))
+    (let ((genesis-block-path (merge-pathnames
+                               (alexandria:assoc-value configuration
+                                                       :genesis-block-file)
+                               directory)))
+      (when (or force
+                (not (probe-file genesis-block-path)))
+        (let ((genesis-block
+               (funcall create-genesis-block
+                        (alexandria:assoc-value configuration :address-for-coins)
+                        (alexandria:assoc-value configuration :stakes))))
+          (emotiq:note "Writing genesis block as JSON to ~a" genesis-block-path)
+          (with-open-file (o genesis-block-path
+                             :direction :output
+                             :if-exists :supersede)
+            (cl-json:encode-json genesis-block o))
         ;;; FIXME: JSON doesn't currently round-trip very well; use LISP-OBJECT-ENCODER as a workaround
-        (with-open-file (o (make-pathname :type "loenc"
-                                          :defaults genesis-block-path)
-                           :element-type '(unsigned-byte 8)
-                           :direction :output
-                           :if-exists :supersede)
-          (lisp-object-encoder:serialize genesis-block o))))))
+          (let ((p (make-pathname :type "loenc"
+                                  :defaults genesis-block-path)))
+            (with-open-file (o p
+                               :element-type '(unsigned-byte 8)
+                               :direction :output
+                               :if-exists :supersede)
+              (lisp-object-encoder:serialize genesis-block o))
+            (emotiq:note "Writing genesis block as LOENC to ~a" p))
+          genesis-block)))))
 
 (defun get-genesis-block ()
   (with-open-file (o (make-pathname :name (pathname-name

--- a/src/gossip/gossip-startup.lisp
+++ b/src/gossip/gossip-startup.lisp
@@ -5,11 +5,6 @@
 (in-package :gossip)
 
 (defparameter *hosts* nil "Cached hosts as read from *hosts-filename* (minus the local machine)")
-(defparameter *stakes* nil "Cached initial value of (pubkey stake) records")
-
-(defun get-stakes ()
-  "Returns cached initial value of (pubkey stake) records"
-  *stakes*)
 
 (defun process-eripa-value (ev)
   (setf *eripa* (if (eq :deduce ev)

--- a/src/gossip/package.lisp
+++ b/src/gossip/package.lisp
@@ -7,7 +7,6 @@
   (:export
    #:cosi-loaded-p
    #:initialize-node
-   #:get-stakes
    #:*nominal-gossip-port*
    #:gossip-startup
    #:ping-other-machines

--- a/src/keys.lisp
+++ b/src/keys.lisp
@@ -5,7 +5,7 @@
 
 The keys of the RECORDS plist are interpreted by gossip/config"
   (loop
-     :with key-integers = (make-key-integers)
+     :for key-integers = (make-key-integers) 
      :for record :in records
      :collecting (append record
                          ;;; HACK adapt to gossip/config needs

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -156,6 +156,7 @@
    #:ensure-defaults
 
    #:get-stakes
+   #:get-genesis-block
 
    #:*dns-ip-zt.emotiq.ch*
    #:settings/read))

--- a/src/stakes.lisp
+++ b/src/stakes.lisp
@@ -1,14 +1,20 @@
 (in-package :emotiq/config)
 
 (defparameter *stakes-filename*
-  "stakes.conf")
-(defparameter *max-stake* (truncate 1E6))
+  (make-pathname :name "stakes" :type "conf"))
+(defparameter *max-stake*
+  (truncate (/ 1E9 1E3))  ;; ratio of total coins to stakers
+  "Maximum amount to award a staked entity")
 
-(defun stakes/generate (pubkeys &key (max-stake *max-stake*))
-  "Given a list of PUBKEYS, generate a random stake for each"
-  (mapcar (lambda (pubkey)
-            (list pubkey (random max-stake)))
-          pubkeys))
+(defun stakes/generate (public-keys &key (max-stake *max-stake*))
+  "Given a list of PUBLIC-KEYS, generate a random stake for each
+
+Returns the enumeration of lists of public keys and staked amounts.
+
+"
+  (mapcar (lambda (pkey)
+            (list pkey (random max-stake)))
+          public-keys))
 
 (defun stakes/write (records &key path)
   (with-open-file (o path
@@ -20,8 +26,8 @@
       (format o "~s~%" stake))))
 
 (defun get-stakes ()
-  (let ((p (make-pathname :name "stakes" :type "conf"
-                          :defaults (emotiq/fs:etc/))))
+  (let ((p (merge-pathnames *stakes-filename*
+                            (emotiq/fs:etc/))))
     (when (probe-file p)
       (with-open-file (o p
                          :direction :input)

--- a/src/t/mvp.lisp
+++ b/src/t/mvp.lisp
@@ -1,5 +1,16 @@
 (in-package :cl-user)
 
+
+;;; INTERNAL testing 
+(prove:plan 1)
+(let* ((nodes-dns-ip emotiq/config:*dns-ip-zt.emotiq.ch*)
+       (nodes (emotiq/config::keys/generate nodes-dns-ip)))
+  (prove:is (length nodes)
+            3
+            "Node key generation for three nodes…")
+  (prove:diag (format nil "Nodes created as ~%~t~s" nodes)))
+
+;;; EXTERNAL testing
 (prove:plan 1)
 (let ((nodes-dns-ip emotiq/config:*dns-ip-zt.emotiq.ch*))
   (prove:ok
@@ -7,8 +18,8 @@
    (format nil "Generation of zt.emotiq.ch devnet artifacts from~%~&~s…"
            nodes-dns-ip)))
 
+(prove:plan 1)
 (let ((stakes (emotiq/config:get-stakes)))
-  (prove:plan 1)
   (prove:ok stakes
             "GET-STAKES returns something…"))
   


### PR DESCRIPTION
Ensure that distinct keys are generated.

Use funcall instead of ASDF dependency to generate configurations.

Correct PROVE:PLAN join point in test annotations.

Fix election requests (dbm)

GENESIS/CREATE returns the created block as well as serializing it

Remove references to stakes from GOSSIP