### PR TITLE
cleaned up, added curve contexts to PBC, should have no external effe…

### DIFF
--- a/src/Crypto/PBC-Intf/pbc_intf.cpp
+++ b/src/Crypto/PBC-Intf/pbc_intf.cpp
@@ -36,74 +36,115 @@ long echo(long nel, char* msg_in, char* msg_out)
 
 // ---------------------------------------------------
 
+typedef struct pairing_context {
+  bool       init_flag;
+  pairing_t  pairing;
+  element_t  g1_gen;
+  element_t  g2_gen;
+} pairing_context_t;
+
+pairing_context_t context[16];
+
+bool& IsInit(int ctxt)
+{
+  return context[ctxt].init_flag;
+}
+
+pairing_t& Pairing(int ctxt)
+{
+  return context[ctxt].pairing;
+}
+
+element_t& G1_gen(int ctxt)
+{
+   return context[ctxt].g1_gen;
+}
+
+element_t& G2_gen(int ctxt)
+{
+  return context[ctxt].g2_gen;
+}
+
+/*
 bool      init_flag = false;
 pairing_t gPairing;
 element_t gG1_gen, gG2_gen; // base generators for G1 and G2
+*/
 
 extern "C"
-long init_pairing(char* param_str, long nel, long* psize)
+long init_pairing(long ctxt, char* param_str, long nel, long* psize)
 {
   long ans;
   
-  if(init_flag)
+  if(IsInit(ctxt))
     {
-      element_clear(gG1_gen);
-      element_clear(gG2_gen);
-      pairing_clear(gPairing);
-      init_flag = false;
+      element_clear(G1_gen(ctxt));
+      element_clear(G2_gen(ctxt));
+      pairing_clear(Pairing(ctxt));
+      IsInit(ctxt) = false;
     }
-  ans = pairing_init_set_buf(gPairing, param_str, nel);
+  ans = pairing_init_set_buf(Pairing(ctxt), param_str, nel);
   if(0 == ans)
     {
       element_t z, pair;
       
-      element_init_G1(gG1_gen, gPairing);
-      element_init_G2(gG2_gen, gPairing);
+      element_init_G1(G1_gen(ctxt), Pairing(ctxt));
+      element_init_G2(G2_gen(ctxt), Pairing(ctxt));
       
-      element_init_GT(pair,    gPairing); // archetypes for sizing info
-      element_init_Zr(z,       gPairing);
+      element_init_GT(pair,    Pairing(ctxt)); // archetypes for sizing info
+      element_init_Zr(z,       Pairing(ctxt));
       
-      element_random(gG1_gen); // default random values
-      element_random(gG2_gen);
+      element_random(G1_gen(ctxt)); // default random values
+      element_random(G2_gen(ctxt));
 
-      psize[0] = element_length_in_bytes_compressed(gG1_gen);
-      psize[1] = element_length_in_bytes_compressed(gG2_gen);
+      psize[0] = element_length_in_bytes_compressed(G1_gen(ctxt));
+      psize[1] = element_length_in_bytes_compressed(G2_gen(ctxt));
       psize[2] = element_length_in_bytes(pair);
       psize[3] = element_length_in_bytes(z);
 
       element_clear(pair);
       element_clear(z);
-      init_flag = true;
+
+      /*
+      memcpy(gPairing, Pairing(ctxt), sizeof(pairing_t));
+      memcpy(gG1_gen, G1_gen(ctxt), sizeof(element_t));
+      memcpy(gG2_gen, G2_gen(ctxt), sizeof(element_t));
+      */
+      
+      IsInit(ctxt) = true;
     }
   return ans;
 }
 
 extern "C"
-long set_g2(unsigned char* pbuf)
+long set_g2(long ctxt,
+	    unsigned char* pbuf)
 {
   // Changing G2 generator invalidates all keying,
   // so remake default random key pair
-  return element_from_bytes_compressed(gG2_gen, pbuf);
+  return element_from_bytes_compressed(G2_gen(ctxt), pbuf);
 }
 
 extern "C"
-long set_g1(unsigned char* pbuf)
+long set_g1(long ctxt,
+	    unsigned char* pbuf)
 {
-  return element_from_bytes_compressed(gG1_gen, pbuf);
+  return element_from_bytes_compressed(G1_gen(ctxt), pbuf);
 }
 
 // --------------------------------------------
 
 extern "C"
-void make_key_pair(unsigned char *pskey, unsigned char* ppkey,
+void make_key_pair(long ctxt,
+		   unsigned char *pskey, unsigned char* ppkey,
 		   unsigned char* phash, long nhash)
 {
   element_t skey, pkey;
-  element_init_Zr(skey, gPairing);
-  element_init_G2(pkey, gPairing);
+  element_init_Zr(skey, Pairing(ctxt));
+  element_init_G2(pkey, Pairing(ctxt));
   
   element_from_hash(skey, phash, nhash);
-  element_pow_zn(pkey, gG2_gen, skey);
+  element_pow_zn(pkey, G2_gen(ctxt), skey);
   element_to_bytes(pskey, skey);
   element_to_bytes_compressed(ppkey, pkey);
 
@@ -112,13 +153,14 @@ void make_key_pair(unsigned char *pskey, unsigned char* ppkey,
 }
  
 extern "C"
-void sign_hash(unsigned char* psig, unsigned char* pskey,
+void sign_hash(long ctxt,
+	       unsigned char* psig, unsigned char* pskey,
 	       unsigned char* phash, long nhash)
 {
   element_t sig, skey;
 
-  element_init_G1(sig,  gPairing);
-  element_init_Zr(skey, gPairing);
+  element_init_G1(sig,  Pairing(ctxt));
+  element_init_Zr(skey, Pairing(ctxt));
   element_from_hash(sig, phash, nhash);
   element_from_bytes(skey, pskey);
   element_pow_zn(sig, sig, skey);
@@ -128,19 +170,20 @@ void sign_hash(unsigned char* psig, unsigned char* pskey,
 }
 
 extern "C"
-void make_public_subkey(unsigned char* abuf,
+void make_public_subkey(long ctxt,
+			unsigned char* abuf,
 			unsigned char* pkey,
 			unsigned char* phash_id, long nhash)
 {
   element_t z;
   element_t gx, gp;
   
-  element_init_Zr(z, gPairing);
-  element_init_G2(gx, gPairing);
-  element_init_G2(gp, gPairing);
+  element_init_Zr(z, Pairing(ctxt));
+  element_init_G2(gx, Pairing(ctxt));
+  element_init_G2(gp, Pairing(ctxt));
   element_from_bytes_compressed(gp, pkey);
   element_from_hash(z, phash_id, nhash);
-  element_pow_zn(gx, gG2_gen, z);
+  element_pow_zn(gx, G2_gen(ctxt), z);
   element_mul(gp, gx, gp);
   element_to_bytes_compressed(abuf, gp); // ans is G2
   element_clear(z);
@@ -149,20 +192,21 @@ void make_public_subkey(unsigned char* abuf,
 }
 
 extern "C"
-void make_secret_subkey(unsigned char* abuf,
+void make_secret_subkey(long ctxt,
+			unsigned char* abuf,
 			unsigned char* skey,
 			unsigned char* phash_id, long nhash)
 {
   element_t z, zs, s;
 
-  element_init_Zr(z, gPairing);
-  element_init_Zr(zs, gPairing);
-  element_init_G1(s, gPairing);
+  element_init_Zr(z, Pairing(ctxt));
+  element_init_Zr(zs, Pairing(ctxt));
+  element_init_G1(s, Pairing(ctxt));
   element_from_hash(z, phash_id, nhash);   // get ID
   element_from_bytes(zs, skey);            // user's secret key
   element_add(z, z, zs);
   element_invert(z, z);
-  element_pow_zn(s, gG1_gen, z);
+  element_pow_zn(s, G1_gen(ctxt), z);
   element_to_bytes_compressed(abuf, s);    // ans is G1
   element_clear(z);
   element_clear(zs);
@@ -170,19 +214,20 @@ void make_secret_subkey(unsigned char* abuf,
 }
 
 extern "C"
-void compute_pairing(unsigned char* gtbuf,
+void compute_pairing(long ctxt,
+		     unsigned char* gtbuf,
 		     unsigned char* hbuf,
 		     unsigned char* gbuf)
 {
   element_t hh, gg, pair;
 
-  element_init_G1(hh,   gPairing);
-  element_init_G2(gg,   gPairing);
-  element_init_GT(pair, gPairing);
+  element_init_G1(hh,   Pairing(ctxt));
+  element_init_G2(gg,   Pairing(ctxt));
+  element_init_GT(pair, Pairing(ctxt));
   
   element_from_bytes_compressed(hh, hbuf);
   element_from_bytes_compressed(gg, gbuf);
-  pairing_apply(pair, hh, gg, gPairing);
+  pairing_apply(pair, hh, gg, Pairing(ctxt));
   element_to_bytes(gtbuf, pair);
   element_clear(pair);
   element_clear(hh);
@@ -190,7 +235,8 @@ void compute_pairing(unsigned char* gtbuf,
 }
 
 extern "C"
-void sakai_kasahara_encrypt(unsigned char* rbuf, // R result in G2
+void sakai_kasahara_encrypt(long ctxt,
+			    unsigned char* rbuf, // R result in G2
 			    unsigned char* pbuf, // pairing result in GT
 			    unsigned char* pkey, // public subkey in G2
 			    unsigned char* phash, long nhash)
@@ -202,16 +248,16 @@ void sakai_kasahara_encrypt(unsigned char* rbuf, // R result in G2
   /* result R = zr*Psubkey */
   /* result pairing e(zr*U,Psubkey) = e(U,zr*Psubkey) */
   
-  element_init_G2(pk, gPairing);
-  element_init_Zr(zr, gPairing);
-  element_init_GT(gt, gPairing);
+  element_init_G2(pk, Pairing(ctxt));
+  element_init_Zr(zr, Pairing(ctxt));
+  element_init_GT(gt, Pairing(ctxt));
   element_from_bytes_compressed(pk, pkey);
   element_from_hash(zr, phash, nhash);
   element_pow_zn(pk, pk, zr);
   element_to_bytes_compressed(rbuf, pk);
 
-  element_pow_zn(pk, gG2_gen, zr);
-  pairing_apply(gt, gG1_gen, pk, gPairing);
+  element_pow_zn(pk, G2_gen(ctxt), zr);
+  pairing_apply(gt, G1_gen(ctxt), pk, Pairing(ctxt));
   element_to_bytes(pbuf, gt);
 
   element_clear(zr);
@@ -220,7 +266,8 @@ void sakai_kasahara_encrypt(unsigned char* rbuf, // R result in G2
 }
 
 extern "C"
-void sakai_kasahara_decrypt(unsigned char* pbuf, // pairing result in GT
+void sakai_kasahara_decrypt(long ctxt,
+			    unsigned char* pbuf, // pairing result in GT
 			    unsigned char* rbuf, // R pt in G2
 			    unsigned char* sbuf) // secret subkey in G1
 {
@@ -229,12 +276,12 @@ void sakai_kasahara_decrypt(unsigned char* pbuf, // pairing result in GT
   /* rk, rbuf is the R value from encryption */
   /* sk, sbuf is the secret_subkey */
   
-  element_init_G1(sk, gPairing);
-  element_init_G2(rk, gPairing);
-  element_init_GT(gt, gPairing);
+  element_init_G1(sk, Pairing(ctxt));
+  element_init_G2(rk, Pairing(ctxt));
+  element_init_GT(gt, Pairing(ctxt));
   element_from_bytes_compressed(sk, sbuf);
   element_from_bytes_compressed(rk, rbuf);
-  pairing_apply(gt, sk, rk, gPairing);
+  pairing_apply(gt, sk, rk, Pairing(ctxt));
   element_to_bytes(pbuf, gt);
   element_clear(sk);
   element_clear(rk);
@@ -242,7 +289,8 @@ void sakai_kasahara_decrypt(unsigned char* pbuf, // pairing result in GT
 }
 			    
 extern "C"
-long sakai_kasahara_check(unsigned char* rkey, // R in G2
+long sakai_kasahara_check(long ctxt,
+			  unsigned char* rkey, // R in G2
 			  unsigned char* pkey, // public subkey in G2
 			  unsigned char* phash, long nhash)
 {
@@ -253,9 +301,9 @@ long sakai_kasahara_check(unsigned char* rkey, // R in G2
   /* pkey, pk1 is the public_subkey */
   /* phash is hash(ID || Tstamp || msg) */
   
-  element_init_G2(pk1, gPairing);
-  element_init_G2(pk2, gPairing);
-  element_init_Zr(zr, gPairing);
+  element_init_G2(pk1, Pairing(ctxt));
+  element_init_G2(pk2, Pairing(ctxt));
+  element_init_Zr(zr, Pairing(ctxt));
   element_from_bytes_compressed(pk1, pkey);
   element_from_bytes_compressed(pk2, rkey);
   element_from_hash(zr, phash, nhash);
@@ -291,37 +339,40 @@ static long get_datum(element_t elt, unsigned char* pbuf, long buflen, bool cmpr
 }
 
 extern "C"
-long get_g2(unsigned char* pbuf, long buflen)
+long get_g2(long ctxt,
+	    unsigned char* pbuf, long buflen)
 {
-  return get_datum(gG2_gen, pbuf, buflen);
+  return get_datum(G2_gen(ctxt), pbuf, buflen);
 }
 
 extern "C"
-long get_g1(unsigned char* pbuf, long buflen)
+long get_g1(long ctxt,
+	    unsigned char* pbuf, long buflen)
 {
-  return get_datum(gG1_gen, pbuf, buflen);
+  return get_datum(G1_gen(ctxt), pbuf, buflen);
 }
 
 // ------------------------------------------------
 
 extern "C"
-long check_signature(unsigned char* psig,
+long check_signature(long ctxt,
+		     unsigned char* psig,
 		     unsigned char* phash, long nhash,
 		     unsigned char *pkey)
 {
   element_t ptHash, ptPKey, ptSig, pair1, pair2;
   long      tf;
-  element_init_G1(ptHash, gPairing);
-  element_init_G1(ptSig,  gPairing);
-  element_init_G2(ptPKey, gPairing);
-  element_init_GT(pair1,  gPairing);
-  element_init_GT(pair2,  gPairing);
+  element_init_G1(ptHash, Pairing(ctxt));
+  element_init_G1(ptSig,  Pairing(ctxt));
+  element_init_G2(ptPKey, Pairing(ctxt));
+  element_init_GT(pair1,  Pairing(ctxt));
+  element_init_GT(pair2,  Pairing(ctxt));
   
   element_from_bytes_compressed(ptSig, psig);
   element_from_hash(ptHash, phash, nhash);
   element_from_bytes_compressed(ptPKey, pkey);
-  pairing_apply(pair1, ptSig,  gG2_gen, gPairing);
-  pairing_apply(pair2, ptHash, ptPKey,  gPairing);
+  pairing_apply(pair1, ptSig,  G2_gen(ctxt), Pairing(ctxt));
+  pairing_apply(pair2, ptHash, ptPKey,  Pairing(ctxt));
   tf = element_cmp(pair1, pair2);
   
   element_clear(ptHash);
@@ -334,13 +385,14 @@ long check_signature(unsigned char* psig,
 }
 
 extern "C"
-void mul_G1_pts(unsigned char* pt1, unsigned char* pt2)
+void mul_G1_pts(long ctxt,
+		unsigned char* pt1, unsigned char* pt2)
 {
   element_t p1, p2;
   long      nel;
   // DO NOT ALLOW pt1 OR pt2 TO BE ZERO ON ENTRY!
-  element_init_G1(p1, gPairing);
-  element_init_G1(p2, gPairing);
+  element_init_G1(p1, Pairing(ctxt));
+  element_init_G1(p2, Pairing(ctxt));
   nel = element_length_in_bytes_compressed(p1);
   element_from_bytes_compressed(p1, pt1);
   element_from_bytes_compressed(p2, pt2);
@@ -354,13 +406,14 @@ void mul_G1_pts(unsigned char* pt1, unsigned char* pt2)
 }
   
 extern "C"
-void mul_G2_pts(unsigned char* pt1, unsigned char* pt2)
+void mul_G2_pts(long ctxt,
+		unsigned char* pt1, unsigned char* pt2)
 {
   element_t p1, p2;
   long      nel;
   // DO NOT ALLOW pt1 OR pt2 TO BE ZERO ON ENTRY!
-  element_init_G2(p1, gPairing);
-  element_init_G2(p2, gPairing);
+  element_init_G2(p1, Pairing(ctxt));
+  element_init_G2(p2, Pairing(ctxt));
   nel = element_length_in_bytes_compressed(p1);
   element_from_bytes_compressed(p1, pt1);
   element_from_bytes_compressed(p2, pt2);
@@ -374,11 +427,12 @@ void mul_G2_pts(unsigned char* pt1, unsigned char* pt2)
 }
   
 extern "C"
-void add_Zr_vals(unsigned char* zr1, unsigned char* zr2)
+void add_Zr_vals(long ctxt,
+		 unsigned char* zr1, unsigned char* zr2)
 {
   element_t z1, z2;
-  element_init_Zr(z1, gPairing);
-  element_init_Zr(z2, gPairing);
+  element_init_Zr(z1, Pairing(ctxt));
+  element_init_Zr(z2, Pairing(ctxt));
   element_from_bytes(z1, zr1);
   element_from_bytes(z2, zr2);
   element_add(z1, z1, z2);
@@ -388,11 +442,12 @@ void add_Zr_vals(unsigned char* zr1, unsigned char* zr2)
 }
   
 extern "C"
-void inv_Zr_val(unsigned char* zr)
+void inv_Zr_val(long ctxt,
+		unsigned char* zr)
 {
   element_t z;
   // DO NOT ALLOW zr TO BE ZERO ON ENTRY!!
-  element_init_Zr(z, gPairing);
+  element_init_Zr(z, Pairing(ctxt));
   element_from_bytes(z, zr);
   element_invert(z, z);
   element_to_bytes(zr, z);
@@ -400,12 +455,13 @@ void inv_Zr_val(unsigned char* zr)
 }
 
 extern "C"
-void exp_G1z(unsigned char* g1, unsigned char* zr)
+void exp_G1z(long ctxt,
+	     unsigned char* g1, unsigned char* zr)
 {
   element_t z, g;
   // DO NOT ALLOW zr TO BE ZERO ON ENTRY!!
-  element_init_Zr(z, gPairing);
-  element_init_G1(g, gPairing);
+  element_init_Zr(z, Pairing(ctxt));
+  element_init_G1(g, Pairing(ctxt));
   element_from_bytes(z, zr);
   element_from_bytes_compressed(g, g1);
   element_pow_zn(g, g, z);
@@ -415,12 +471,13 @@ void exp_G1z(unsigned char* g1, unsigned char* zr)
 }
   
 extern "C"
-void exp_G2z(unsigned char* g2, unsigned char* zr)
+void exp_G2z(long ctxt,
+	     unsigned char* g2, unsigned char* zr)
 {
   element_t z, g;
   // DO NOT ALLOW zr TO BE ZERO ON ENTRY!!
-  element_init_Zr(z, gPairing);
-  element_init_G2(g, gPairing);
+  element_init_Zr(z, Pairing(ctxt));
+  element_init_G2(g, Pairing(ctxt));
   element_from_bytes(z, zr);
   element_from_bytes_compressed(g, g2);
   element_pow_zn(g, g, z);
@@ -430,33 +487,36 @@ void exp_G2z(unsigned char* g2, unsigned char* zr)
 }
 
 extern "C"
-void get_G1_from_hash(unsigned char *g1_pt, unsigned char *phash, long nhash)
+void get_G1_from_hash(long ctxt,
+		      unsigned char *g1_pt, unsigned char *phash, long nhash)
 {
   element_t g;
 
-  element_init_G1(g, gPairing);
+  element_init_G1(g, Pairing(ctxt));
   element_from_hash(g, phash, nhash);
   element_to_bytes_compressed(g1_pt, g);
   element_clear(g);
 }
 
 extern "C"
-void get_G2_from_hash(unsigned char *g2_pt, unsigned char *phash, long nhash)
+void get_G2_from_hash(long ctxt,
+		      unsigned char *g2_pt, unsigned char *phash, long nhash)
 {
   element_t g;
 
-  element_init_G2(g, gPairing);
+  element_init_G2(g, Pairing(ctxt));
   element_from_hash(g, phash, nhash);
   element_to_bytes_compressed(g2_pt, g);
   element_clear(g);
 }
 
 extern "C"
-void get_Zr_from_hash(unsigned char *zr_val, unsigned char *phash, long nhash)
+void get_Zr_from_hash(long ctxt,
+		      unsigned char *zr_val, unsigned char *phash, long nhash)
 {
   element_t z;
 
-  element_init_Zr(z, gPairing);
+  element_init_Zr(z, Pairing(ctxt));
   element_from_hash(z, phash, nhash);
   element_to_bytes(zr_val, z);
   element_clear(z);

--- a/src/Crypto/PBC-Intf/pbc_intf.h
+++ b/src/Crypto/PBC-Intf/pbc_intf.h
@@ -33,46 +33,46 @@ THE SOFTWARE.
 
 extern "C" {
   long echo(long nel, char* msg_in, char* msg_out);
-  long init_pairing(char* param_str, long nel, long* psize);
-  long set_g2(unsigned char* pbuf);
-  long set_g1(unsigned char* pbuf);
-  void make_key_pair(unsigned char* pskey, unsigned char* ppkey,
+  long init_pairing(long ctxt, char* param_str, long nel, long* psize);
+  long set_g2(long ctxt, unsigned char* pbuf);
+  long set_g1(long ctxt, unsigned char* pbuf);
+  void make_key_pair(long ctxt, unsigned char* pskey, unsigned char* ppkey,
 		     unsigned char* phash, long nhash);
-  void sign_hash(unsigned char* psig, unsigned char* pskey,
+  void sign_hash(long ctxt, unsigned char* psig, unsigned char* pskey,
 		 unsigned char* phash, long nhash);
-  void make_public_subkey(unsigned char* abuf,
+  void make_public_subkey(long ctxt, unsigned char* abuf,
 			  unsigned char* pkey,
 			  unsigned char* phash_id, long nhash);
-  void make_secret_subkey(unsigned char* abuf,
+  void make_secret_subkey(long ctxt, unsigned char* abuf,
 			  unsigned char* skey,
 			  unsigned char* phash_id, long nhash);
-  void compute_pairing(unsigned char* gtbuf,
+  void compute_pairing(long ctxt, unsigned char* gtbuf,
 		       unsigned char* hbuf,
 		       unsigned char* gbuf);
-  void sakai_kasahara_encrypt(unsigned char* rbuf, // R result in G2
+  void sakai_kasahara_encrypt(long ctxt, unsigned char* rbuf, // R result in G2
 			      unsigned char* pbuf, // pairing result in GT
 			      unsigned char* pkey, // public subkey in G2
 			      unsigned char* phash, long nhash);
-  void sakai_kasahara_decrypt(unsigned char* pbuf, // pairing result in GT
+  void sakai_kasahara_decrypt(long ctxt, unsigned char* pbuf, // pairing result in GT
 			      unsigned char* rbuf, // R pt in G2
 			      unsigned char* sbuf); // secret subkey in G1
-  long sakai_kasahara_check(unsigned char* rkey, // R in G2
+  long sakai_kasahara_check(long ctxt, unsigned char* rkey, // R in G2
 			    unsigned char* pkey, // public subkey in G2
 			    unsigned char* phash, long nhash);
-  long get_g2(unsigned char* pbuf, long buflen);
-  long get_g1(unsigned char* pbuf, long buflen);
-  long check_signature(unsigned char* psig,
+  long get_g2(long ctxt, unsigned char* pbuf, long buflen);
+  long get_g1(long ctxt, unsigned char* pbuf, long buflen);
+  long check_signature(long ctxt, unsigned char* psig,
 		       unsigned char* phash, long nhash,
 		       unsigned char *pkey);
-  void mul_G1_pts(unsigned char* pt1, unsigned char* pt2);
-  void mul_G2_pts(unsigned char* pt1, unsigned char* pt2);
-  void add_Zr_vals(unsigned char* zr1, unsigned char* zr2);
-  void inv_Zr_val(unsigned char* zr);
-  void exp_G1z(unsigned char* g1, unsigned char* zr);
-  void exp_G2z(unsigned char* g2, unsigned char* zr);
-  void get_G1_from_hash(unsigned char *g1_pt, unsigned char *phash, long nhash);
-  void get_G2_from_hash(unsigned char *g2_pt, unsigned char *phash, long nhash);
-  void get_Zr_from_hash(unsigned char *zr_val, unsigned char *phash, long nhash);
+  void mul_G1_pts(long ctxt, unsigned char* pt1, unsigned char* pt2);
+  void mul_G2_pts(long ctxt, unsigned char* pt1, unsigned char* pt2);
+  void add_Zr_vals(long ctxt, unsigned char* zr1, unsigned char* zr2);
+  void inv_Zr_val(long ctxt, unsigned char* zr);
+  void exp_G1z(long ctxt, unsigned char* g1, unsigned char* zr);
+  void exp_G2z(long ctxt, unsigned char* g2, unsigned char* zr);
+  void get_G1_from_hash(long ctxt, unsigned char *g1_pt, unsigned char *phash, long nhash);
+  void get_G2_from_hash(long ctxt, unsigned char *g2_pt, unsigned char *phash, long nhash);
+  void get_Zr_from_hash(long ctxt, unsigned char *zr_val, unsigned char *phash, long nhash);
 }
 
 // -- end of pbc_intf.h -- //

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -168,6 +168,7 @@ THE SOFTWARE.
 ;; Init interface - this must be performed first
 
 (cffi:defcfun ("init_pairing" _init-pairing) :long
+  (context     :long)
   (param-text  :pointer :unsigned-char)
   (ntext       :long)
   (psizes      :pointer :long))
@@ -176,10 +177,12 @@ THE SOFTWARE.
 ;; Query interface
 
 (cffi:defcfun ("get_g2" _get-g2) :long
+  (context     :long)
   (pbuf        :pointer :void)
   (nbuf        :long))
 
 (cffi:defcfun ("get_g1" _get-g1) :long
+  (context     :long)
   (pbuf        :pointer :void)
   (nbuf        :long))
 
@@ -187,27 +190,32 @@ THE SOFTWARE.
 ;; Setter interface
 
 (cffi:defcfun ("set_g2" _set-g2) :long
+  (context     :long)
   (pbuf   :pointer :unsigned-char))
 
 (cffi:defcfun ("set_g1" _set-g1) :long
+  (context     :long)
   (pbuf   :pointer :unsigned-char))
 
 ;; -------------------------------------------------
 ;; Keying interface
 
 (cffi:defcfun ("make_key_pair" _make-key-pair) :void
+  (context     :long)
   (skbuf  :pointer :unsigned-char)
   (pkbuf  :pointer :unsigned-char)
   (hbuf   :pointer :unsigned-char)
   (nhash  :long))
 
 (cffi:defcfun ("make_public_subkey" _make-public-subkey) :void
+  (context     :long)
   (abuf   :pointer :unsigned-char)
   (pbuf   :pointer :unsigned-char)
   (hbuf   :pointer :unsigned-char)
   (hlen   :long))
 
 (cffi:defcfun ("make_secret_subkey" _make-secret-subkey) :void
+  (context     :long)
   (abuf   :pointer :unsigned-char)
   (sbuf   :pointer :unsigned-char)
   (hbuf   :pointer :unsigned-char)
@@ -215,6 +223,7 @@ THE SOFTWARE.
 
 (cffi:defcfun ("sakai_kasahara_encrypt" _sakai-kasahara-encrypt) :void
   ;; aka SAKKE, IETF RFC 6508
+  (context     :long)
   (rbuf   :pointer :unsigned-char) ;; returned R point in G2
   (pbuf   :pointer :unsigned-char) ;; returned pairing for encryption in GT
   (pkey   :pointer :unsigned-char) ;; public subkey in G2
@@ -223,12 +232,14 @@ THE SOFTWARE.
 
 (cffi:defcfun ("sakai_kasahara_decrypt" _sakai-kasahara-decrypt) :void
   ;; aka SAKKE, IETF RFC 6508
+  (context     :long)
   (pbuf   :pointer :unsigned-char)  ;; returned pairing for decryptin in GT
   (rbuf   :pointer :unsigned-char)  ;; R point in G2
   (skey   :pointer :unsigned-char)) ;; secret subkey in G1
 
 (cffi:defcfun ("sakai_kasahara_check" _sakai-kasahara-check) :long
   ;; aka SAKKE, IETF RFC 6508
+  (context     :long)
   (rbuf   :pointer :unsigned-char)  ;; R point in G2
   (pkey   :pointer :unsigned-char)  ;; public subkey in G2
   (hbuf   :pointer :unsigned-char)  ;; hash(ID, msg)
@@ -238,12 +249,14 @@ THE SOFTWARE.
 ;; BLS Signatures
 
 (cffi:defcfun ("sign_hash" _sign-hash) :void
+  (context     :long)
   (sig    :pointer :unsigned-char)
   (skbuf  :pointer :unsigned-char)
   (pbuf   :pointer :unsigned-char)
   (nbuf   :long))
 
 (cffi:defcfun ("check_signature" _check-signature) :long
+  (context     :long)
   (psig   :pointer :unsigned-char)
   (phash  :pointer :unsigned-char)
   (nhash  :long)
@@ -253,29 +266,36 @@ THE SOFTWARE.
 ;; Curve math ops
 
 (cffi:defcfun ("mul_G1_pts" _mul-g1-pts) :void
+  (context     :long)
   (p1    :pointer :unsigned-char)
   (p2    :pointer :unsigned-char))
 
 (cffi:defcfun ("mul_G2_pts" _mul-g2-pts) :void
+  (context     :long)
   (p1    :pointer :unsigned-char)
   (p2    :pointer :unsigned-char))
 
 (cffi:defcfun ("add_Zr_vals" _add-zr-vals) :void
+  (context     :long)
   (z1    :pointer :unsigned-char)
   (z2    :pointer :unsigned-char))
 
 (cffi:defcfun ("inv_Zr_val" _inv-zr-val) :void
+  (context     :long)
   (z     :pointer :unsigned-char))
 
 (cffi:defcfun ("exp_G1z" _exp-G1z) :void
+  (context     :long)
   (g     :pointer :unsigned-char)
   (z     :pointer :unsigned-char))
 
 (cffi:defcfun ("exp_G2z" _exp-G2z) :void
+  (context     :long)
   (g     :pointer :unsigned-char)
   (z     :pointer :unsigned-char))
 
 (cffi:defcfun ("compute_pairing" _compute-pairing) :void
+  (context     :long)
   (gtbuf :pointer :unsigned-char)  ;; result returned here
   (hbuf  :pointer :unsigned-char)
   (gbuf  :pointer :unsigned-char))
@@ -283,16 +303,19 @@ THE SOFTWARE.
 ;; ----------------------------------------------------
 
 (cffi:defcfun ("get_G1_from_hash" _get-g1-from-hash) :void
+  (context     :long)
   (g1buf :pointer :unsigned-char)
   (hbuf  :pointer :unsigned-char)
   (nhash :long))
 
 (cffi:defcfun ("get_G2_from_hash" _get-g2-from-hash) :void
+  (context     :long)
   (g2buf :pointer :unsigned-char)
   (hbuf  :pointer :unsigned-char)
   (nhash :long))
 
 (cffi:defcfun ("get_Zr_from_hash" _get-zr-from-hash) :void
+  (context     :long)
   (zrbuf :pointer :unsigned-char)
   (hbuf  :pointer :unsigned-char)
   (nhash :long))
@@ -389,6 +412,7 @@ not belonging to any field"))
 (defstruct (full-curve-params
             (:include curve-params))
   ;; cached values filled in at init
+  context
   order g1-len g2-len zr-len gt-len)
 
 ;; ---------------------------------------------------------------------------------------
@@ -686,6 +710,7 @@ comparison.")
 (define-symbol-macro *g1*            (curve-params-g1      *curve*)) ;; generator for G1
 (define-symbol-macro *g2*            (curve-params-g2      *curve*)) ;; generator for G2
 
+(define-symbol-macro *context*       (full-curve-params-context *curve*)) ;; which context of PBC? (0..15)
 (define-symbol-macro *curve-order*   (full-curve-params-order   *curve*)) ;; order of all groups (G1,G2,Zr,Gt)
 (define-symbol-macro *g1-size*       (full-curve-params-g1-len  *curve*)) ;; G1 corresponds to the h curve
 (define-symbol-macro *g2-size*       (full-curve-params-g2-len  *curve*)) ;; G2 corresponds to the g curve for keying
@@ -724,7 +749,7 @@ comparison.")
 (defvar *crypto-lock*  (mpcompat:make-lock)
   "Used to protect internal startup routines from multiple access")
 
-(defun init-pairing (&optional (params nil params-supplied-p))
+(defun init-pairing (&key (params nil params-supplied-p) (context 0))
   "Initialize the pairings lib.
 
   If params not specified and we haven't been called yet, or specified
@@ -741,8 +766,8 @@ also mutate the state of the lib, and so are similarly protected from
 SMP access. Everything else should be SMP-safe."
   (mpcompat:with-lock (*crypto-lock*)
     (let ((prev   *curve*)
-          (params (or params
-                      *curve-fr449-params*)))
+          (cparams (or params
+                       *curve-fr449-params*)))
       ;; If params not specified, and we have already been called,
       ;; just skip doing anything.
       (when (or params-supplied-p
@@ -751,16 +776,17 @@ SMP access. Everything else should be SMP-safe."
 	(load-dlls)
         (with-accessors ((txt  curve-params-pairing-text)
                          (g1   curve-params-g1)
-                         (g2   curve-params-g2)) params
+                         (g2   curve-params-g2)) cparams
           (cffi:with-foreign-pointer (ansbuf #.(* 4 (cffi:foreign-type-size :long)))
             (cffi:with-foreign-string ((ctxt ntxt) txt
                                        :encoding :ASCII)
-              (assert (zerop (_init-pairing ctxt ntxt ansbuf)))
+              (assert (zerop (_init-pairing context ctxt ntxt ansbuf)))
               (setf *curve* (make-full-curve-params
-                             :name          (curve-params-name         params)
-                             :pairing-text  (curve-params-pairing-text params)
-                             :g1            (curve-params-g1           params)
-                             :g2            (curve-params-g2           params))
+                             :name          (curve-params-name         cparams)
+                             :pairing-text  (curve-params-pairing-text cparams)
+                             :g1            (curve-params-g1           cparams)
+                             :g2            (curve-params-g2           cparams)
+                             :context       context)
                     *g1-size*  (cffi:mem-aref ansbuf :long 0)
                     *g2-size*  (cffi:mem-aref ansbuf :long 1)
                     *gt-size*  (cffi:mem-aref ansbuf :long 2)
@@ -830,7 +856,7 @@ SMP access. Everything else should be SMP-safe."
   "Internal routine to read a (possibly compressed) element from the C
 library."
   (with-fli-buffers ((buf nb))
-    (assert (eql nb (funcall get-fn buf nb)))
+    (assert (eql nb (funcall get-fn *context* buf nb)))
     (xfer-foreign-to-lisp buf nb)))
               
 ;; -------------------------------------------------
@@ -894,7 +920,7 @@ library."
   (let ((nb  (hash-length hash)))
     (with-fli-buffers ((ptbuf  *g1-size*)
                        (hbuf   nb  hash))
-      (_get-g1-from-hash ptbuf hbuf nb)
+      (_get-g1-from-hash *context* ptbuf hbuf nb)
       (make-instance 'g1-cmpr
                      :pt  (xfer-foreign-to-lisp ptbuf *g1-size*))
       )))
@@ -904,7 +930,7 @@ library."
   (let ((nb (hash-length hash)))
   (with-fli-buffers ((ptbuf  *g2-size*)
                      (hbuf   nb  hash))
-    (_get-g2-from-hash ptbuf hbuf nb)
+    (_get-g2-from-hash *context* ptbuf hbuf nb)
     (make-instance 'g2-cmpr
                    :pt  (xfer-foreign-to-lisp ptbuf *g2-size*))
     )))
@@ -914,7 +940,7 @@ library."
   (let ((nb (hash-length hash)))
     (with-fli-buffers ((zbuf   *zr-size*)
                        (hbuf   nb  hash))
-      (_get-zr-from-hash zbuf hbuf nb)
+      (_get-zr-from-hash *context* zbuf hbuf nb)
       (make-instance 'zr
                      :val  (xfer-foreign-to-lisp zbuf *zr-size*))
       )))
@@ -926,7 +952,7 @@ library."
   (mpcompat:with-lock (*crypto-lock*)
     (let ((bytes (crypto-val-vec x)))
       (with-fli-buffers ((buf nb bytes))
-        (funcall set-fn buf)))))
+        (funcall set-fn *context* buf)))))
 
 (defmethod set-generator ((g1 g1-cmpr))
   "Set the cryptosystem G1 generator"
@@ -946,7 +972,7 @@ library."
     (with-fli-buffers ((sigbuf *g1-size*)
                        (skbuf  *zr-size* skey)
                        (hbuf nhash hash))
-      (_sign-hash sigbuf skbuf hbuf nhash)
+      (_sign-hash *context* sigbuf skbuf hbuf nhash)
       (make-instance 'signature
                      :val (xfer-foreign-to-lisp sigbuf *g1-size*))
       )))
@@ -964,7 +990,7 @@ library."
     (with-fli-buffers ((sbuf *g1-size*  sig)
                        (hbuf nhash      hash)
                        (pbuf *g2-size*  pkey))
-      (zerop (_check-signature sbuf hbuf nhash pbuf))
+      (zerop (_check-signature *context* sbuf hbuf nhash pbuf))
       )))
 
 (defmethod check-hash ((hash hash) sig pkey)
@@ -1016,7 +1042,7 @@ Certification includes a BLS Signature on the public key."
     (with-fli-buffers ((sbuf *zr-size*)
                        (pbuf *g2-size*)
                        (hbuf hlen hsh))
-      (_make-key-pair sbuf pbuf hbuf hlen)
+      (_make-key-pair *context* sbuf pbuf hbuf hlen)
       (let* ((pkey (make-instance 'public-key
                                   :val (xfer-foreign-to-lisp pbuf *g2-size*)))
              (skey (make-instance 'secret-key
@@ -1047,7 +1073,7 @@ Certification includes a BLS Signature on the public key."
     (with-fli-buffers ((hbuf hlen      hsh)
                        (pbuf *g2-size* (public-key-val pkey))
                        (abuf *g2-size*))
-      (_make-public-subkey abuf pbuf hbuf hlen)
+      (_make-public-subkey *context* abuf pbuf hbuf hlen)
       (make-instance 'public-subkey
                      :val (xfer-foreign-to-lisp abuf *g2-size*)))))
 
@@ -1060,7 +1086,7 @@ Certification includes a BLS Signature on the public key."
     (with-fli-buffers ((hbuf hlen      hsh)
                        (sbuf *zr-size* (secret-key-val skey))
                        (abuf *g1-size*))
-      (_make-secret-subkey abuf sbuf hbuf hlen)
+      (_make-secret-subkey *context* abuf sbuf hbuf hlen)
       (make-instance 'secret-subkey
                      :val (xfer-foreign-to-lisp abuf *g1-size*)))))
 
@@ -1107,7 +1133,7 @@ Certification includes a BLS Signature on the public key."
                        (pbuf  *gt-size*)         ;; returned pairing
                        (kbuf  *g2-size*  pkid)   ;; public key
                        (rbuf  *g2-size*))        ;; returned R value
-      (_sakai-kasahara-encrypt rbuf pbuf kbuf hbuf 32)
+      (_sakai-kasahara-encrypt *context* rbuf pbuf kbuf hbuf 32)
       (let* ((pval (get-hash-nbytes xlen (xfer-foreign-to-lisp pbuf *gt-size*)))
              (cmsg (make-instance 'crypto-text
                                   :vec (construct-bev
@@ -1137,7 +1163,7 @@ Certification includes a BLS Signature on the public key."
       (with-fli-buffers ((pbuf  *gt-size*)
                          (kbuf  *g1-size*  skid)
                          (rbuf  *g2-size*  rval))
-        (_sakai-kasahara-decrypt pbuf rbuf kbuf)
+        (_sakai-kasahara-decrypt *context* pbuf rbuf kbuf)
         (let* ((cmsg-bytes (raw-bytes cmsg))
                (nb         (length cmsg-bytes))
                (pval (get-hash-nbytes nb (xfer-foreign-to-lisp pbuf *gt-size*)))
@@ -1146,7 +1172,7 @@ Certification includes a BLS Signature on the public key."
                (hval (hash/256 id tstamp msg)))
           (with-fli-buffers ((hbuf 32        hval)
                              (kbuf *g2-size* pkey))
-            (when (zerop (_sakai-kasahara-check rbuf kbuf hbuf 32))
+            (when (zerop (_sakai-kasahara-check *context* rbuf kbuf hbuf 32))
               (loenc:decode (raw-bytes msg))))
           )))))
 
@@ -1159,7 +1185,7 @@ Certification includes a BLS Signature on the public key."
   (with-fli-buffers ((hbuf  *g1-size*  hval)
                      (gbuf  *g2-size*  gval)
                      (gtbuf *gt-size*))
-    (_compute-pairing gtbuf hbuf gbuf)
+    (_compute-pairing *context* gtbuf hbuf gbuf)
     (make-instance 'pairing
                    :val (xfer-foreign-to-lisp gtbuf *gt-size*))))
 
@@ -1174,7 +1200,7 @@ Certification includes a BLS Signature on the public key."
   ;; it is assumed that the a-siz is also the size of result.
   (with-fli-buffers ((a-buf  a-siz  a)
                      (b-buf  b-siz  b))
-    (funcall op a-buf b-buf) ;; result returned in first arg buffer
+    (funcall op *context* a-buf b-buf) ;; result returned in first arg buffer
     (funcall final (xfer-foreign-to-lisp a-buf a-siz))))
 
 (defun make-g1-ans (ans)
@@ -1232,7 +1258,7 @@ Certification includes a BLS Signature on the public key."
   (when (zerop (int z))
     (error "Can't invert zero"))
   (with-fli-buffers ((z-buf  *zr-size* z))
-    (_inv-zr-val z-buf)
+    (_inv-zr-val *context* z-buf)
     (make-instance 'zr
                    :val (xfer-foreign-to-lisp z-buf *zr-size*))))
 


### PR DESCRIPTION
…ct in existing code.

Please merge to dev at your convenience. Not an urgent request. Unit tests perform satisfactorily, and no client code changes are mandated by these additions.

Multiple curve sets can be active at once with curve contexts. Init-pairings takes keyword args which default to our current curve-fr449-params and context 0. Context is an integer (0..15). All C primitives now require the context argument to be able to find the parameters for the curves and pairing field in question. 

This allows for future support of multiple PBC curve sets, in an SMP-safe manner. I intend to invent a WITH-CURVE macro that will dynamically bind *CURVE* to whichever curve you select, and the context for that curve was established and recorded in the curve parameters struct at the time INIT-PAIRING was called.

There should be no apparent behavior changes for all running code. No required changes to any of our running code. The changes affect only the pbc-cffi.lisp and pbc_intf.h/pbc_intf.cpp sources, and their mode of inter-communication.