### PR TITLE
Use configuration of REST and Websocket listen addresses

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -134,13 +134,15 @@
                                      :type "conf"))
   (genesis/create configuration :directory directory :force t))
   
-(defun settings/read () 
+(defun settings/read (&optional key) 
   (unless (probe-file *emotiq-conf*)
     (emotiq:note "No configuration able to be read from '~a'" *emotiq-conf*)
     (return-from settings/read nil))
   ;;; TODO: do gossip/configuration sequence
-  (cl-json:decode-json-from-source *emotiq-conf*))
-
+  (let ((c (cl-json:decode-json-from-source *emotiq-conf*)))
+    (if key
+        (alexandria:assoc-value c key)
+        c)))
 
 (defun ensure-defaults (&key
                           (c (copy-alist +default-configuration+))

--- a/src/startup.lisp
+++ b/src/startup.lisp
@@ -30,11 +30,16 @@
   ;; Create a default wallet on disk if one doesn't already exist
   (emotiq/wallet:create-wallet)
   ;; Start the websocket interface for the Electron wallet
-  ;; listening <ws://localhost:3145/wallet> .
-  (websocket/wallet:start-server :port 3145)
+  ;; listening <ws://localhost:PORT/wallet> .
+  (when (string-equal "true"
+                      (emotiq/config:settings/read :websocket-server))
+    (websocket/wallet:start-server :port (emotiq/config:settings/read :websocket-server-port)))
   ;; Start the REST server which provides support for testing the
-  ;; WebSocket implementation at <http://localhost:3140/client/>
-  (emotiq-rest:start-server :port 3140)
+  ;; WebSocket implementation at <http://localhost:PORT/client/>
+  (when (string-equal "true"
+                      (emotiq/config:settings/read :rest-server))
+    (emotiq-rest:start-server :port (emotiq/config:settings/read :rest-server-port)))
+
   (emotiq/tracker:start-tracker)
   (emotiq:start-node)
   (cosi-simgen:startup-elections))


### PR DESCRIPTION
@echupriyanov This code actually uses the configuration for the REST/Websocket routines, which will be necessary to avoid port collisions on the local machine running more than one process.