### PR TITLE
Add :config-subpath option to main so now you can say

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -14,7 +14,7 @@
     (:hostname "zt-emq-03.zt.emotiq.ch"
      :ip "10.178.15.71")))
 
-(defparameter *emotiq-conf*
+(defun emotiq-conf ()
   (make-pathname :defaults (emotiq/fs:etc/)
                  :name "emotiq-conf"
                  :type "json"))
@@ -123,7 +123,7 @@
    :private (alexandria:assoc-value configuration :private)
    :key-records key-records)
   (with-open-file (o (make-pathname :defaults directory
-                                    :name (pathname-name *emotiq-conf*)
+                                    :name (pathname-name (emotiq-conf))
                                     :type "json")
                      :if-exists :supersede
                      :direction :output)
@@ -135,11 +135,11 @@
   (genesis/create configuration :directory directory :force t))
   
 (defun settings/read (&optional key) 
-  (unless (probe-file *emotiq-conf*)
-    (emotiq:note "No configuration able to be read from '~a'" *emotiq-conf*)
+  (unless (probe-file (emotiq-conf))
+    (emotiq:note "No configuration able to be read from '~a'" (emotiq-conf))
     (return-from settings/read nil))
   ;;; TODO: do gossip/configuration sequence
-  (let ((c (cl-json:decode-json-from-source *emotiq-conf*)))
+  (let ((c (cl-json:decode-json-from-source (emotiq-conf))))
     (if key
         (alexandria:assoc-value c key)
         c)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -124,6 +124,7 @@
   (:nicknames #:emotiq/fs
               #:emotiq/path)
   (:export
+   #:*subpath*
    #:emotiq/user/root/
    #:emotiq/wallet/
    #:tmp/

--- a/src/startup.lisp
+++ b/src/startup.lisp
@@ -23,9 +23,17 @@
 
 (in-package "EMOTIQ")
 
+(defun directorify (str)
+  "Ensure str doesn't start with #\/ but it does end with one"
+  (let ((slash #.(string #\/)))
+    (setf str (string-trim slash str))
+    (setf str (concatenate 'string str slash))))
+
 ;; "Entry Point" for development - does nothing, just load and go
-(defun main (&optional how-started-message?)
+(defun main (&key config-subpath how-started-message?)
   (setf cosi-simgen::*use-real-gossip* t) ;; make sure code knows 
+  (when config-subpath
+    (setf emotiq/fs:*subpath* (directorify config-subpath)))
   (message-running-state how-started-message?)
   ;; Create a default wallet on disk if one doesn't already exist
   (emotiq/wallet:create-wallet)


### PR DESCRIPTION
Add :config-subpath option to main so now you can say
`(emotiq:main :config-subpath "nodeN/")`
to enable running multiple emotiq nodes on localhost.

If you supply this arg, config files (and others defined in `filesystem.lisp`) will have the given subpath appended to them e.g.

instead of the default `../var/etc/`
config files will be found in `../var/etc/nodeN/`.

Other functions like `tmp/` etc are affected similarly.