### PR TITLE
Add test for simulator to keep it working

### DIFF
--- a/etc/all-tests.sexp
+++ b/etc/all-tests.sexp
@@ -2,5 +2,6 @@
  :gossip-test
  :crypto-pairings-test
  :emotiq-config-test
- :cosi-bls-test)
+ :cosi-bls-test
+ :emotiq-sim-test)
  

--- a/src/Cosi-BLS/cosi-bls.asd
+++ b/src/Cosi-BLS/cosi-bls.asd
@@ -31,6 +31,7 @@ THE SOFTWARE.
   :depends-on (emotiq/logging
                ironclad
                actors
+               emotiq/utilities
                emotiq/tracker
                emotiq/config
                core-crypto

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -381,6 +381,9 @@ THE SOFTWARE.
                      :text txt)))
 
   (defmethod view-tree ((tree node) &key (layout :left-right))
+    (unless (emotiq:x11-display-p)
+      (emotiq:note "No X11 display available to view tree")
+      (return-from view-tree nil))
     (capi:contain
      (make-instance 'capi:graph-pane
                     :layout-function layout

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -84,10 +84,11 @@
                 :pathname "./"
                 :components ((:file "node")))))
 
-(defsystem "emotiq/sim"  ;; a simulated node
+(defsystem "emotiq/sim"  ;; a simulated network entirely within the local process
   :depends-on (emotiq/cli
                alexandria
 	       emotiq/tracker)
+  :in-order-to ((test-op (test-op "emotiq-sim-test")))
   :components ((:module source
                 :pathname "./"
                 :components ((:file "handler")

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -56,8 +56,10 @@ N.B. :nodes has no effect unless a new configuration has been triggered (see abo
   (phony-up-nodes)
   (emotiq/elections:set-nodes (keys-and-stakes))
   (emotiq/tracker:start-tracker)
-  (when run-cli-p
-    (emotiq/cli:main)))
+  (if run-cli-p
+      (emotiq/cli:main)
+      ;;; FIXME:  return nil when initialization is not successful
+      t))
 
 (defvar *genesis-account*
   nil
@@ -191,7 +193,9 @@ This will spawn an actor which will asynchronously do the following:
               ;; allow leader elections to create this block
               (publish-transaction (setf *tx-2* trans) "tx-2"))))))
   (sleep 60)
-  (emotiq:note "current state = ~A" (emotiq/tracker:query-current-state)))
+  (let ((result (emotiq/tracker:query-current-state)))
+    (emotiq:note "current state = ~A" result)
+    result))   ;;; return non-nil if we are able to exit cleanly
 
 (defun run-new-tx ()
   "Using new tx feature, run the block chain simulation entirely within the current process.
@@ -359,8 +363,9 @@ This will spawn an actor which will asynchronously do the following:
             (format t "~3%Here's a dump of the whole blockchain currently:~%")
             (cosi/proofs/newtx:dump-txs :blockchain t)
             (format t "~2%Good-bye and good luck!~%"))))))
-  (emotiq:note "current state = ~A" (emotiq/tracker:query-current-state))
-  (values))
+  (let ((result (emotiq/tracker:query-current-state)))
+    (emotiq:note "current state = ~A" result)
+    result))  ;;; return non-nil if we are able to exit cleanly
 
 (defun blocks ()
   "Return the blocks in the chain currently under local simulation

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -45,6 +45,9 @@
    #:emotiq/log/)
 
   (:export
+   #:x11-display-p)
+
+  (:export
    #:start-node)
   (:export
    #:*notestream*

--- a/src/test/emotiq-sim-test.asd
+++ b/src/test/emotiq-sim-test.asd
@@ -1,0 +1,17 @@
+(defsystem "emotiq-sim-test"
+  :version "0.1.0"
+  :description "Emotiq"
+  :author "Copyright (c) 2018 Emotiq AG"
+  :license "MIT (see LICENSE.txt)"
+  :depends-on (lisp-unit
+               emotiq/sim)
+  :perform (test-op (o s)
+                    (symbol-call :lisp-unit :run-tests
+                                 :all :emotiq-sim-test))
+  :components ((:module package
+                :pathname "./"
+                :components ((:file "package")))
+               (:module tests
+                :depends-on (package)
+                :pathname "./"
+                :components ((:file "simulator")))))

--- a/src/test/package.lisp
+++ b/src/test/package.lisp
@@ -5,5 +5,8 @@
 (defpackage #:emotiq-config-test
   (:use #:cl #:emotiq #:lisp-unit))
 
+(defpackage #:emotiq-sim-test
+  (:use #:cl #:lisp-unit))
+
 
 

--- a/src/test/simulator.lisp
+++ b/src/test/simulator.lisp
@@ -1,0 +1,9 @@
+(in-package :emotiq-sim-test)
+
+(define-test simulated-chain ()
+  (assert-true (emotiq/sim:initialize :nodes 3 :new-configuration-p t))
+  (assert-true (emotiq/sim:run-new-tx))
+  (assert-true (> (length (emotiq/sim:blocks))
+                  1)))
+
+             

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -68,3 +68,9 @@
    (length string)
    :initial-contents string 
    :element-type 'character))
+
+
+(defun x11-display-p ()
+  "Whether the process is capable of being an X11 client"
+  (not (null (uiop:getenv "DISPLAY"))))
+


### PR DESCRIPTION
While we get the network transport working, it is important to keep the simulator working as it is currently the only source of "truth" about whether transactions work or not.

Closes #321.