### PR TITLE
Dbm fix actors note interaction

### DIFF
--- a/src/Actors/actors-startup.lisp
+++ b/src/Actors/actors-startup.lisp
@@ -187,8 +187,14 @@ THE SOFTWARE.
 
 (defun blind-print (cmd &rest items)
   (declare (ignore cmd))
+  (let ((prfn (get :actors :print-handler)))
   (dolist (item items)
-    (emotiq:note "~A" item)))
+    (funcall prfn item))))
+
+(eval-when (:load-toplevel)
+  (unless (get :actors :print-handler)
+    (setf (get :actors :print-handler) 'print)))
+
 
 (defvar *shared-printer-actor*    #'blind-print)
 
@@ -201,8 +207,7 @@ THE SOFTWARE.
           (make-actor
            (dlambda
             (:print (&rest things-to-print)
-                    (dolist (item things-to-print)
-                      (emotiq:note "~A" item)))
+             (apply 'blind-print :print things-to-print))
             
             (:quit () (become 'blind-print))
             )))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -179,7 +179,8 @@ THE SOFTWARE.
 (defmethod node-dispatcher ((msg-sym (eql :block-finished)) &key)
   (emotiq/tracker:track :block-finished)
   (emotiq:note "Block committed to blockchain")
-  (emotiq:note "Block signatures = ~D" (logcount (block-signature-bitmap (first *blockchain*)))))
+  (emotiq:note "Block signatures = ~D" (logcount (block-signature-bitmap (first *blockchain*))))
+  (send-hold-election))
 
 ;; ------------------------------------------------------------------------------------
 

--- a/src/note.lisp
+++ b/src/note.lisp
@@ -41,6 +41,11 @@ a CL:FORMAT control string referencing the values contained in ARGS."
     (record-note timestring " " outstring)
     outstring))
 
+(eval-when (:load-toplevel)
+  ;; hook, even if Actors isn't loaded...
+  ;; If Actors are loaded later, they will respect the hook
+  (setf (get :actors :print-handler) (um:curry 'note "~A")))
+
 (defun em-warn (message-or-format &rest args)
   "Like note but this is for warnings."
   (let ((timestring (timestring))


### PR DESCRIPTION
This uses a benign hook, stored as a property on the keyword symbol :ACTORS, to allow EMOTIQ:NOTE to override the behavior of Actors::blind-print. 

If Actors is loaded first, it knows nothing about EMOTIQ package. And so it installs its own hook function = PRINT. But if Emotiq:NOTE is later loaded, it will override with a formatted call to NOTE.

If Actors is loaded after NOTE, then it leaves the hook alone, respecting the override.

If Actors is never loaded, no harm, no foul. Just a function stored on a property list of some symbol.

But it is important that all packages be able to view the hook without needing to know about any other package. Hence we use the keyword symbols package, which is ubiquitous.