### PR TITLE
fix broadcast problem with nil dest, trap unexpected GOSSIP messages …

### DIFF
--- a/src/test/simulator.lisp
+++ b/src/test/simulator.lisp
@@ -3,6 +3,10 @@
 (define-test simulated-chain ()
   (assert-true (emotiq/sim:initialize :nodes 3 :new-configuration-p t))
   (assert-true (emotiq/sim:run-new-tx))
+  ;; --- NEED TO WAIT HERE.. ---
+  ;; run-new-tx exits early due to async Actors taking over for the work.
+  ;; (blocks) contains nothing until the run gets further along
+  (sleep 10)
   (assert-true (> (length (emotiq/sim:blocks))
                   1)))
 


### PR DESCRIPTION
I found a couple problems in the code.

for some reason I was getting an error in the Gossip layer, after a broadcast was issued. I found that by specifying :startNodID = my local pkey, it got past that error.

After (1), I'm now getting unexpected :GOSSIP messages in the Cosi application layer. These contain a NIL second argument and a GOSSIP:SOLICITATION with my own local pkey as the third argument.

As a workaround, I put in a message handler for :GOSSIP messages and print a log entry of Unexpected Gossip Message, along with the contents.

In emotiq-sim-test, you init a new network with 3 nodes, then fire off the sim. But sim returns immediately after tossing transactions to the sim network, and Actors take over doing the work. Hence, when sim returns, the blockchain is still empty - needs a delay of around 10+ sec before anything could be in the blockchain.
Putting in the delay allows the emotiq-sim-test to pass.