### PR TITLE
Dev us dbm 275

### DIFF
--- a/src/Actors/actors-startup.lisp
+++ b/src/Actors/actors-startup.lisp
@@ -187,9 +187,16 @@ THE SOFTWARE.
 
 (defun blind-print (cmd &rest items)
   (declare (ignore cmd))
-  (let ((prfn (get :actors :print-handler)))
-  (dolist (item items)
-    (funcall prfn item))))
+  (let ((prfn (get :actors :print-handler))
+        (fmt  (first items)))
+    (cond ((and (stringp fmt)
+                (find #\~ fmt))
+           (funcall prfn (apply 'format nil fmt (rest items))))
+
+          (t
+           (dolist (item items)
+             (funcall prfn item)))
+          )))
 
 (eval-when (:load-toplevel)
   (unless (get :actors :print-handler)

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -390,7 +390,7 @@ THE SOFTWARE.
 
   (defmethod view-tree ((tree node) &key (layout :left-right))
     (unless (emotiq:x11-display-p)
-      (emotiq:note "No X11 display available to view tree")
+      (pr "No X11 display available to view tree")
       (return-from view-tree nil))
     (capi:contain
      (make-instance 'capi:graph-pane

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -212,6 +212,8 @@
    :edec
    :pbc)
   (:shadow block)            ; used internally, not required for users
+  (:import-from :actors
+   pr)
   (:export 
    transaction-id
    make-genesis-transaction
@@ -336,6 +338,8 @@
    :startup-elections
    :short-id
    :node-id-str
+   :set-nodes
+   :get-witness-list
    ))
 
 (defpackage :cosi-keying

--- a/src/node-sim.lisp
+++ b/src/node-sim.lisp
@@ -557,25 +557,25 @@ the cosi-simgen implementation of the simulator."
 (defun kill-beacon ()
   (emotiq/elections:kill-beacon))
 
-(defun nodes ()
-  "Return a list of all nodes under simulation"
-  (alexandria:hash-table-values cosi-simgen:*ip-node-tbl*))
-
 ;; ----------------------------------------------------------------
 ;; These disappear once Gossip is installed...
 ;; 
 
 (defun phony-up-nodes ()
-  (maphash (lambda (k node)
-             (declare (ignore k))
-             (setf (cosi-simgen:node-stake node) (random 100000)))
-           cosi-simgen:*ip-node-tbl*))
+  (cosi-simgen:set-nodes
+   (um:accum acc
+     (maphash (lambda (k node)
+                (declare (ignore k))
+                (let ((pkey  (cosi-simgen:node-pkey node))
+                      (stake (random 100000)))
+                  (setf (cosi-simgen:node-stake node) stake)
+                  (ac:pr (list pkey stake))
+                  (acc (list pkey stake))))
+              cosi-simgen:*ip-node-tbl*))))
 
 (defun keys-and-stakes ()
   "Return a list of lists of public key and stake for nodes"
-  (mapcar (lambda (node)
-            (list (cosi-simgen:node-pkey node) (cosi-simgen:node-stake node)))
-          (nodes)))
+  (cosi-simgen:get-witness-list))
 
 ;; END? of "those which disappear once Gossip in installed…"
 ;; ----------------------------------------------------------------

--- a/src/state-tracker.lisp
+++ b/src/state-tracker.lisp
@@ -15,27 +15,27 @@
   (if (and
        (eql (first msg) :reset)
        (null *tracking-actor*))
-      (emotiq:note "~%*** Don't care :reset ***~%")  ;; don't care about this condition
+      (ac:pr "~%*** Don't care :reset ***~%")  ;; don't care about this condition
     (actors:send *tracking-actor* msg)))
 
 (defun start-tracker ()
   "returns an actor that can be sent messages about changes to the system state"
   (setf *state* (make-instance 'system-state)
         *tracking-actor* (actors:make-actor #'do-tracking))
-  (emotiq:note "running start-tracker ~A ~A" *state* *tracking-actor*))
+  (ac:pr "running start-tracker ~A ~A" *state* *tracking-actor*))
 
 (defun do-tracking (msg)
   (case (first msg) 
     (:reset
-     (emotiq:note "Tracker: :reset - state cleared")
+     (ac:pr "Tracker: :reset - state cleared")
      (start-tracker))
 
     (:election
-     (emotiq:note "Tracker: :election - state cleared")
+     (ac:pr "Tracker: :election - state cleared")
      (start-tracker))
 
     (:block-finished
-     (emotiq:note "Tracker: :block-finished, state = ~A" (query-current-state)))
+     (ac:pr "Tracker: :block-finished, state = ~A" (query-current-state)))
 
     ((:make-block :commit :prepare)
      ;; tbd
@@ -43,12 +43,12 @@
     
     (:new-leader
      (let ((leader-node (second msg)))
-       (emotiq:note "Tracker: New Leader ~A" (stringify-node leader-node))
+       (ac:pr "Tracker: New Leader ~A" (stringify-node leader-node))
        (setf (system-leader *state*) leader-node)))
     
     (:new-witness
      (let ((witness-node (second msg)))
-       (emotiq:note "Tracker: New witness ~A" (stringify-node witness-node))
+       (ac:pr "Tracker: New witness ~A" (stringify-node witness-node))
        (push witness-node (system-witness-list *state*))))))
 
 (defun query-current-state ()


### PR DESCRIPTION
change calls to emotiq:note to use ac:pr instead, in all Cosi (Actor-based) portions of the code.

AC:PR now accepts a leading string arg, which if it contains a #~ char, will act as a format string and absorb remaining args. Otherwise all args are printed in a DOLIST manner, as before.

We still vector through the print-handler hook that emotiq:note sets up to produce timestamped output.

Try to reduce use of IP-NODE-TBL, as now defunct, directing all queries for nodes and stakes through (GET-WITNESS-LIST), which returns a list of pairs (pkey stake). Nodes are referred to by public key, not IP addresses.

Fix up node-sim.lisp to behave properly with respect to (GET-WITNESS-LIST).