### PR TITLE
Dev us dbm 276

### DIFF
--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -245,8 +245,7 @@ based on their relative stake"
   ;; knocked out, then we fall back to early elections with BFT
   ;; consensus on decision to resync.
   (let ((self      (current-actor))
-        (node      (current-node))
-        (witnesses (get-witness-list)))
+        (node      (current-node)))
     
     (with-accessors ((stake       node-stake) ;; only used for diagnostic messages
                      (pkey        node-pkey)


### PR DESCRIPTION
Put in code to fill in the witness/stake list from config.

We are using *USE-REAL-GOSSIP* as an indication that we are running on AWS, and not on the 1-machine internal simulator.