### PR TITLE
Improvements to `demo-network/start-blockchain.bash`

### DIFF
--- a/demo-network/README.md
+++ b/demo-network/README.md
@@ -64,6 +64,10 @@ Add lines:
 set -g history-limit 50000
 run-shell ~/.tmux/plugins/tmux-logging/logging.tmux
 ```
+On `macOS` its also recommended to install `ansifilter` utility:
+```bash
+brew install ansifilter
+```
 
 ## Running blockchain
 

--- a/demo-network/start-blockchain.bash
+++ b/demo-network/start-blockchain.bash
@@ -5,6 +5,15 @@ EMOTIQ_ROOT=$DIR/..
 
 # Pull in all dependencies
 $EMOTIQ_ROOT/ci/lisp-wrapper.bash -e '(ql:quickload :emotiq/startup)'
+status=$?
+
+if  [ $status -ne 0 ] ; then
+  echo "Failed to quickload Emotiq dependencies"
+  exit 1
+fi
+
+# Stop running node, if any
+${DIR}/stop-blockchain.bash > /dev/null 2>&1
 
 # Start the Emotiq blockchain
 for i in {1..3} ; do


### PR DESCRIPTION
* Terminate script, if `(ql:quickload :emotiq/startup)` fails
* Terminate running nodes, before trying to start new ones.

Closes #363 
Closes #362 