### PR TITLE
Add `coreutils` macOS depenedency to the README.md

### DIFF
--- a/demo-network/README.md
+++ b/demo-network/README.md
@@ -27,11 +27,13 @@ To run the network, following tools have to be installed:
 * rlwrap
 * netcat
 
+`macOS` also needs `coreutils` to be installed
+
 They can be installed using following shell commands:
 
 * **macOS**
   ```bash
-  brew install tmux rlwrap netcat
+  brew install tmux rlwrap netcat coreutils
   ```
 * **Linux**
   ```bash
@@ -68,6 +70,8 @@ On `macOS` its also recommended to install `ansifilter` utility:
 ```bash
 brew install ansifilter
 ```
+
+`tmux-logging` plugin places logs in $HOME directory.
 
 ## Running blockchain
 


### PR DESCRIPTION
Also, mention that `tmux-logging` places logs in $HOME directory

Resolves #371 