### PR TITLE
Fix spurious Actor system watchdog notifications

### DIFF
--- a/src/Actors/packages.lisp
+++ b/src/Actors/packages.lisp
@@ -50,6 +50,7 @@ THE SOFTWARE.
    #:prio-mailbox
    #:make-prio-mailbox
    #:mailbox-read
+   #:mailbox-peek
    #:mailbox-send
    #:mailbox-empty-p
    #:make-unsafe-fifo

--- a/src/data-objects/packages.lisp
+++ b/src/data-objects/packages.lisp
@@ -64,6 +64,7 @@ THE SOFTWARE.
    #:make-priq
    #:addq
    #:popq
+   #:peekq
    #:emptyq-p
    #:contents
    #:findq
@@ -73,6 +74,7 @@ THE SOFTWARE.
    #:make-prio-mailbox
    #:mailbox-send
    #:mailbox-read
+   #:mailbox-peek
    #:mailbox-empty-p
    #:mailbox-not-empty-p
    ))


### PR DESCRIPTION
extend queues with PEEK function, reimplement actor-ready-queue to hold pairs (fn timestamp), and reimplement watchdog timer to check (A) is ready queue empty?, and if not, (B) is the timestamp in the next entry older than watchdog limit? If so, prompt for action from user with watchdog handler.

The aim is to prevent spurious watchdog notifications that arose at random intervals due to a race condition in the method previously used to check for system stalls.