### PR TITLE
Dev us dbm self repairing

### DIFF
--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -184,7 +184,7 @@ added to the blockchain."
       (when prev-block? 
         (with-slots (prev-block-hash)
             blk
-          (setf prev-block-hash (hash-block prev-block?))))
+          (setf prev-block-hash (int (hash-block prev-block?)))))
       blk)))
 
 

--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -176,7 +176,7 @@ added to the blockchain."
       (setf timestamp (- (get-universal-time) *unix-epoch-ut*))
       (setf election-proof block-election-proof)
       (setf leader-pkey block-leader-pkey)
-      (setf witnesses block-witnesses)
+      (setf witnesses (coerce block-witnesses 'vector))
       (setf transactions block-transactions)
       (setf merkle-root-hash (compute-merkle-root-hash blk))
       (setf input-script-merkle-root-hash (compute-input-script-merkle-root-hash blk))

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,9 +195,9 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (um:when-let (blk (gethash id *blockchain-tbl*))
+      (um:when-let (blk (gethash (int id) *blockchain-tbl*))
         (acc blk)
-        (iter (int (block-prev-block-hash blk)))
+        (iter (block-prev-block-hash blk))
         ))))
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -150,11 +150,10 @@ THE SOFTWARE.
 
 (defmethod initialize-instance :after ((node node) &key &allow-other-keys)
   (when (null (node-blockchain node))
-    (let ((genesis-block (emotiq/config:get-genesis-block)))
-      (push genesis-block (node-blockchain node))
-      (setf (gethash (cosi/proofs:hash-block genesis-block)
-                     (node-blockchain-tbl node))
-            genesis-block))))
+    (let* ((genesis-block (emotiq/config:get-genesis-block))
+           (hashID        (hash-block genesis-block)))
+      (setf (node-blockchain node) hashID
+            (gethash hashID (node-blockchain-tbl node)) genesis-block))))
 
 ;; --------------------------------------------------------------
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -167,9 +167,9 @@ THE SOFTWARE.
   (and *blockchain*
        (gethash *blockchain* *blockchain-tbl*)))
 
-(defun block-list ()
+(defun block-list (&optional (from *blockchain*))
   (um:accum acc
-    (um:nlet-tail iter ((id *blockchain*))
+    (um:nlet-tail iter ((id from))
       (unless (null id)
         (let ((blk (gethash id *blockchain-tbl*)))
           (acc blk)

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,10 +195,11 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (um:when-let (blk (gethash (int id) *blockchain-tbl*))
-        (acc blk)
-        (iter (block-prev-block-hash blk))
-        ))))
+      (when id
+          (um:when-let (blk (gethash (int id) *blockchain-tbl*))
+            (acc blk)
+            (iter (block-prev-block-hash blk))
+            )))))
 
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -196,7 +196,9 @@ THE SOFTWARE.
   (um:accum acc
     (um:nlet-tail iter ((id from))
       (when id
+        ;; terminate on null reference (from genesis block)
           (um:when-let (blk (gethash (int id) *blockchain-tbl*))
+            ;; or terminate when missing the block
             (acc blk)
             (iter (block-prev-block-hash blk))
             )))))

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -68,9 +68,6 @@ THE SOFTWARE.
              :initform (make-subs))
    (bit      :accessor node-bit      ;; bit position in bitmap
              :initform 0)
-   (stake    :accessor node-stake
-             :initarg  :stake
-             :initform 0)
    ;; -------------------------------------
    ;; pseudo-globals per node
    (blockchain     :accessor node-blockchain

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,11 +195,10 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (unless (zerop id)
-        (let ((blk (gethash id *blockchain-tbl*)))
-          (acc blk)
-          (iter (int (block-prev-block-hash blk)))
-          )))))
+      (um:when-let (blk (gethash id *blockchain-tbl*))
+        (acc blk)
+        (iter (int (block-prev-block-hash blk)))
+        ))))
 
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,7 +195,7 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (unless (null id)
+      (unless (zerop id)
         (let ((blk (gethash id *blockchain-tbl*)))
           (acc blk)
           (iter (int (block-prev-block-hash blk)))

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -76,8 +76,7 @@ THE SOFTWARE.
    (blockchain     :accessor node-blockchain
                    :initform nil)
    (blockchain-tbl :accessor node-blockchain-tbl
-                   :initform (make-hash-table
-                              :test 'equalp))
+                   :initform (make-hash-table))
    (mempool        :accessor  node-mempool
                    :initform  (make-hash-table
                                :test 'equalp))
@@ -161,6 +160,21 @@ THE SOFTWARE.
 
 (defun gen-uuid-int ()
   (uuid:uuid-to-integer (uuid:make-v1-uuid)))
+
+;; --------------------------------------------------------------
+
+(defun latest-block ()
+  (and *blockchain*
+       (gethash *blockchain* *blockchain-tbl*)))
+
+(defun block-list ()
+  (um:accum acc
+    (um:nlet-tail iter ((id *blockchain*))
+      (unless (null id)
+        (let ((blk (gethash id *blockchain-tbl*)))
+          (acc blk)
+          (iter (int (block-prev-block-hash blk)))
+          )))))
 
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -197,11 +197,13 @@ THE SOFTWARE.
     (um:nlet-tail iter ((id from))
       (when id
         ;; terminate on null reference (from genesis block)
-          (um:when-let (blk (gethash (int id) *blockchain-tbl*))
-            ;; or terminate when missing the block
-            (acc blk)
-            (iter (block-prev-block-hash blk))
-            )))))
+          (um:if-let (blk (gethash (int id) *blockchain-tbl*))
+            (progn
+              ;; or terminate when missing the block
+              (acc blk)
+              (iter (block-prev-block-hash blk)))
+            (warn "Missing block ~A -- you might want to ask for a back-fill" (short-id id)))
+          ))))
 
 
 

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -245,7 +245,6 @@ THE SOFTWARE.
   (let* ((bits  (block-signature-bitmap blk))
          (pkey  (composite-pkey blk bits)))
     (and (int= blkID (hash-block blk))            ;; is it really the block I think it is?
-         (>= (logcount bits) (bft-threshold blk)) ;; does it have BFT thresh signatures?
          (check-block-multisignature blk)         ;; does the signature check out?
          )))
 
@@ -943,8 +942,10 @@ check that each TXIN and TXOUT is mathematically sound."
   (let* ((bits  (block-signature-bitmap blk))
          (sig   (block-signature blk))
          (hash  (hash/256 (signature-hash-message blk))))
-    (and (check-hash-multisig hash sig bits blk)
-         (check-block-transactions-hash blk))
+    (and (find (block-leader-pkey blk) (block-witnesses blk) ;; is the purported Leader in the witness list?
+               :test 'int=)
+         (check-hash-multisig hash sig bits blk)  ;; does the multisignature validate?
+         (check-block-transactions-hash blk))     ;; do the transactions hash to the header Merkel hash?
     ))
 
 (defun call-for-punishment ()

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -271,6 +271,9 @@ THE SOFTWARE.
                       (um:when-let (newID (block-prev-block-hash blk)) ;; do I have predecessor?
                         (assert (integerp newID))
                         (unless (gethash newID *blockchain-tbl*)
+                          ;; NOTE: While the following may appear to be a recursive call,
+                          ;; the semantics of ACTORS:RECV ensure that it performs in constant
+                          ;; stack space.
                           (sync-blockchain node newID))))  ;; if not, then ask for it
                      (t
                       ;; wasn't what I asked for, or invalid block response

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -217,7 +217,9 @@ THE SOFTWARE.
        (unless (find (node-pkey node) *dead-node-pkeys*
                      :test 'int=)
          ;;; Source of majority of messages on screen makes it fairly verbose
-         (pr "Cosi MSG: ~A" (mapcar 'short-id msg))
+         (pr "Cosi MSG: Node ~A ~A"
+             (short-id node)
+             (mapcar 'short-id msg))
          (um:dcase msg
            (:actor-callback (aid &rest ans)
             (let ((actor (lookup-actor-for-aid aid)))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -247,7 +247,6 @@ THE SOFTWARE.
          (pkey  (composite-pkey blk bits)))
     (and (int= blkID (hash-block blk))            ;; is it really the block I think it is?
          (>= (logcount bits) (bft-threshold blk)) ;; does it have BFT thresh signatures?
-         (int= pkey (composite-pkey blk bits))    ;; is the signature pkey properly formed?
          (pbc:check-hash blkid                    ;; does the signature check out?
                          (block-signature blk)
                          pkey)

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -197,6 +197,7 @@ THE SOFTWARE.
   (send-hold-election))     ;; b'cast to witness pool
 
 (defmethod node-dispatcher ((msg-sym (eql :blockchain-head)) &key pkey hashID sig)
+  (assert (integerp hashID))
   (unless (eql *blockchain* hashID)
     (pr "Missing block head ~A, requesting fill" hashID)
     (setf *blockchain* hashID)
@@ -245,6 +246,7 @@ THE SOFTWARE.
           )))))
 
 ;; -------------------------------------------------------------------------------------
+;; Blockchain Sync
 
 (defun ask-neighbor-node (&rest msg)
   (let* ((my-pkey (node-pkey (current-node)))
@@ -973,6 +975,10 @@ check that each TXIN and TXOUT is mathematically sound."
   (make-signed-message (make-blockchain-comment-message-skeleton pkey hashID)))
 
 (defun send-blockchain-comment ()
+  (pr "TEST - Blockchain = ~A" *blockchain*)
+  (inspect *blockchain*)
+  (assert (or (null *blockchain*)
+              (integerp *blockchain*)))
   (gossip:broadcast (make-signed-blockchain-comment-message (node-pkey (current-node))
                                                             *blockchain*)
                     :graphID :UBER))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -1,4 +1,3 @@
-
 ;;
 ;; DM/Emotiq  02/18
 ;; ---------------------------------------------------------------
@@ -247,9 +246,7 @@ THE SOFTWARE.
          (pkey  (composite-pkey blk bits)))
     (and (int= blkID (hash-block blk))            ;; is it really the block I think it is?
          (>= (logcount bits) (bft-threshold blk)) ;; does it have BFT thresh signatures?
-         (pbc:check-hash blkid                    ;; does the signature check out?
-                         (block-signature blk)
-                         pkey)
+         (check-block-multisignature blk)         ;; does the signature check out?
          )))
 
 (defun sync-blockchain (node hashID &optional (retries 1))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -174,8 +174,7 @@ THE SOFTWARE.
     (unless (eql *blockchain* hashID)
       (pr "Missing block head ~A, requesting fill" (short-id hashID))
       (setf *blockchain* hashID)
-      (spawn 'sync-blockchain (current-node) hashID))))
-
+      (start-backfill (current-node) hashID))))
 
 (defvar *max-query-depth*  8)
 
@@ -286,6 +285,16 @@ THE SOFTWARE.
             :TIMEOUT    timeout
             :ON-TIMEOUT (retry-ask)
             ))))))
+
+(defun start-backfill (node fromID)
+  ;; User callable backfill starter - need to provide a reference to
+  ;; the NODE structure to be backfilled, and a starting block ID hash
+  ;; value.
+  ;;
+  ;; If you received a warning about a missing block when calling
+  ;; (BLOCK-LIST) then the block ID you need is the prev-block-hash in
+  ;; the header of the last block in your returned list.
+  (spawn 'sync-blockchain node fromID))
 
 ;; --------------------------------------------------------------------
 

--- a/src/Cosi-BLS/cosi-netw-xlat.lisp
+++ b/src/Cosi-BLS/cosi-netw-xlat.lisp
@@ -92,14 +92,6 @@ THE SOFTWARE.
     (gossip-send pkey nil msg)))
         
 ;; --------------------------------------------------------------
-
-(defparameter *cosi-port*   65001)
-
-(defmethod translate-pkey-to-ip-port ((pkey pbc:public-key))
-  (let ((node (gethash (int pkey) *pkey-node-tbl*)))
-    (values (node-real-ip node) *cosi-port*)))
-
-;; --------------------------------------------------------------
 ;; THE SOCKET INTERFACE, TILL GOSSIP IS UP...
 ;; --------------------------------------------------------------
 
@@ -122,52 +114,4 @@ THE SOFTWARE.
       ;; return the contained message
       (pbc:signed-message-msg decoded))
     ))
-
-;; -----------------------------------------------------
-;; THE SOCKET INTERFACE...
-;; -----------------------------------------------------
-
-(defun port-routing-handler (buf)
-  (let ((packet (verify-hmac buf)))
-    (unless packet
-      (pr "Invalid packet"))
-    (when packet
-      ;; Every incoming packet is scrutinized for a valid HMAC. If
-      ;; it checks out then the packet is dispatched to an
-      ;; operation.  Otherwise it is just dropped on the floor.
-
-      ;; we can only arrive here if the incoming buffer held a valid
-      ;; packet
-      (progn ;; ignore-errors
-        ;; might not be a properly destructurable packet
-        (destructuring-bind (dest &rest msg) packet
-          (let ((node (gethash (int dest) *pkey-node-tbl*)))
-            (unless node
-              (pr :Non-existent-node))
-            (when node
-              (when (eq node *my-node*)
-                (pr (format nil "fowarding-by-default-to-me: ~A" msg)))
-              (apply 'ac:send (node-self node) msg)))))
-      )))
-
-(defvar *handler* (make-actor 'port-routing-handler))
-
-;;; For binary delivery, we need to allocate keypair memory at
-;;; runtime.
-(let ((hmac-keypair nil)
-      (hmac-keypair-mutex (mpcompat:make-lock)))
-  (defun hmac-keypair ()
-    (unless hmac-keypair
-      (mpcompat:with-lock (hmac-keypair-mutex)
-        (setf hmac-keypair
-              (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid))))))
-    hmac-keypair)
-  (defmethod socket-send (ip port dest msg)
-    (declare (ignore ip port))
-    (let* ((payload (make-hmac (list* dest msg)
-                               (pbc:keying-triple-pkey (hmac-keypair))
-                               (pbc:keying-triple-skey (hmac-keypair))))
-           (packet  (loenc:encode payload)))
-      (ac:send *handler* packet)
-      )))
 

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -338,7 +338,7 @@ based on their relative stake"
 
 (defmethod node-dispatcher ((msg-sym (eql :call-for-new-election)) &key pkey epoch sig)
   (when (and (validate-call-for-election-message pkey epoch sig) ;; valid call-for-election?
-             (or (pr "Got call for new election") t)
+             (or (pr "Node ~A got call for new election" (short-id (current-node))) t)
              (>= (length *election-calls*)
                 (bft-threshold (get-witness-list))))
     (run-special-election)))

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -227,9 +227,9 @@ based on their relative stake"
   (let ((self      (current-actor))
         (node      (current-node)))
     
-    (with-accessors ((pkey  node-pkey)) node
+    (with-accessors ((me  node-pkey)) node
 
-      (update-election-seed pkey)
+      (update-election-seed me)
 
       (let* ((winner     (hold-election n))
              (new-beacon (hold-election n (remove winner (emotiq/config:get-stakes)
@@ -243,18 +243,18 @@ based on their relative stake"
         
         (pr "~A got :hold-an-election ~A" (short-id node) n)
         (pr "election results ~A (stake = ~A)"
-                     (if (int= pkey winner) " *ME* " " not me ")
+                     (if (int= me winner) " *ME* " " not me ")
                      (stake-for winner))
         (pr "winner ~A me=~A"
                      (short-id winner)
-                     (short-id pkey))
+                     (short-id me))
 
-        (when (int= pkey new-beacon)
+        (when (int= me new-beacon)
           ;; launch a beacon
           (node-schedule-after *mvp-election-period*
             (send-hold-election)))
 
-        (cond ((int= pkey winner)
+        (cond ((int= me winner)
                ;; why not use ac:self-call?  A: Because doing it with
                ;; send, instead, allows queued up messages to be
                ;; handled first. Might be some transactions waiting to

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -209,11 +209,10 @@ based on their relative stake"
    
 (defvar *mvp-election-period*  20) ;; seconds between election rounds
 
-(defun my-stake (node)
-  (let* ((pkey (node-pkey node))
-         (pair (find pkey (emotiq/config:get-stakes)
-                     :key  'first
-                     :test 'int=)))
+(defun stake-for (pkey)
+  (let ((pair (find pkey (emotiq/config:get-stakes)
+                    :key  'first
+                    :test 'int=)))
     (and pair
          (cadr pair))))
 
@@ -232,8 +231,7 @@ based on their relative stake"
 
       (update-election-seed pkey)
 
-      (let* ((stake      (my-stake node)) ;; used only for diagnostic display
-             (winner     (hold-election n))
+      (let* ((winner     (hold-election n))
              (new-beacon (hold-election n (remove winner (emotiq/config:get-stakes)
                                                   :key 'first
                                                   :test 'int=))))
@@ -246,7 +244,7 @@ based on their relative stake"
         (pr "~A got :hold-an-election ~A" (short-id node) n)
         (pr "election results ~A (stake = ~A)"
                      (if (int= pkey winner) " *ME* " " not me ")
-                     stake)
+                     (stake-for winner))
         (pr "winner ~A me=~A"
                      (short-id winner)
                      (short-id pkey))

--- a/src/Cosi-BLS/new-transactions.lisp
+++ b/src/Cosi-BLS/new-transactions.lisp
@@ -1056,7 +1056,7 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
    blocks of the blockchain (i.e., the value of cosi-simgen:*blockchain*)
    beginning the most recent minted and ending with the genesis block, with
    BLOCK-VAR bound during each iteration to the block."
-  `(loop for ,block-var in cosi-simgen:*blockchain*
+  `(loop for ,block-var in (cosi-simgen:block-list)
          do (progn ,@body)))
 
 (defmacro do-transactions ((tx-var blk) &body body)

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -333,6 +333,7 @@
    :latest-block
    :kill-node
    :enable-node
+   :start-backfill
    ))
 
 (defpackage :cosi-keying

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -329,6 +329,8 @@
    :set-nodes
    :get-witness-list
    :with-current-node
+   :block-list
+   :latest-block
    ))
 
 (defpackage :cosi-keying

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -331,6 +331,8 @@
    :with-current-node
    :block-list
    :latest-block
+   :kill-node
+   :enable-node
    ))
 
 (defpackage :cosi-keying


### PR DESCRIPTION
`*BLOCKCHAIN*` now contains the (integer) block hash of the latest block
used in conjunction with `*BLOCKCHAIN-TBL*`.

`(LATEST-BLOCK)` - returns the block corresponding to the ID in `*BLOCKCHAIN*`
`(BLOCK-LIST &OPTIONAL (FROM *BLOCKCHAIN*))` - returns a simple list, ordered from latest toward earliest, beginning at FROM. Blocks identified by integer hash code of the block header.

`(KILL-NODE PKEY)` - disable message dispatching to the indicated node (node identified by PKey)
`(ENABLE-NODE PKEY)` - enables message dispatching to the indicated node (if it was disabled)

Self repairing blockchain in each node. Leader broadcasts, to entire network, the ID of the latest block, even if no new block has been produced. If a node detects that its `*BLOCKCHAIN*` differs from the broadcast, it begins asking for backfill till it finds a block that it already knows about, or until genesis block (NIL prev-hash) is found. This backfilling occurs in a separate Actor so that the node remains responsive to normal message flow between nodes.

Backfilling occurs by asking a random node for the block. If that node has the block it is sent back to the requester, where it is validated and then added to its own blockchain. If the asked node does not have the block, it will ask one of its own neighbors (randomly selected) to try, as long as the depth of the forwarding is below `*MAX-QUERY-DEPTH*` (default to 8 levels). If requester doesn't get a valid answer within 60 sec, it tries a new query, up to 3 tries. If returned block points to another block that it doesn't know about, a new request is issued for that predecessor block. until it either already knows the predecessor block, or the genesis block has been reached. Back-filling occurs in parallel with normal message handling activities on a related but separate Actor. (related by referring to same NODE structure)

Block validation at the requestor is: (1) does the block header actually hash to the ID requested? (2) does the multisignature contain a BFT threshold number of signatories? (3) does the multisignature validate against the header hash? (4) do the block transactions actually hash to the header Merkel hash?

The :BLOCKCHAIN-HEAD message is broadcast by Leader separately from :HOLD-AN-ELECTION. The intent here is that :BLOCKCHAIN-HEAD Is to be widely broadcast to anyone listening, while :HOLD-AN-ELECTION is intended only for the staked witness pool. Eventually, there may become a distinction for selective broadcasts.  :BLOCKCHAIN-HEAD message is issued by Leader node for every epoch, even if no new block has been produced. So newly joining nodes need only wait for one election epoch to transpire before learning of blockchain head. And they automatically begin back filling by seeing that the broadcast blockchain head ID differs from their own, initially NIL, blockchain ID.

Clean up SHORT-ID to provide terser diagnostic displays

Explanatory comments added below...
