### PR TITLE
Self-setting NODE context

### DIFF
--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -184,7 +184,7 @@ added to the blockchain."
       (when prev-block? 
         (with-slots (prev-block-hash)
             blk
-          (setf prev-block-hash (hash-block prev-block?))))
+          (setf prev-block-hash (int (hash-block prev-block?)))))
       blk)))
 
 

--- a/src/Cosi-BLS/block.lisp
+++ b/src/Cosi-BLS/block.lisp
@@ -176,7 +176,7 @@ added to the blockchain."
       (setf timestamp (- (get-universal-time) *unix-epoch-ut*))
       (setf election-proof block-election-proof)
       (setf leader-pkey block-leader-pkey)
-      (setf witnesses block-witnesses)
+      (setf witnesses (coerce block-witnesses 'vector))
       (setf transactions block-transactions)
       (setf merkle-root-hash (compute-merkle-root-hash blk))
       (setf input-script-merkle-root-hash (compute-input-script-merkle-root-hash blk))

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -174,7 +174,8 @@ THE SOFTWARE.
 
 ;; new for Gossip support, and conceptually cleaner...
 (defmethod initialize-instance :around ((node node) &key &allow-other-keys)
-  (setf (node-self node) (make-node-dispatcher node))
+  (setf (node-self node) (make-node-dispatcher node)
+        *current-node*   node)
   (call-next-method))
 
 (defmethod initialize-instance :after ((node node) &key &allow-other-keys)

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,9 +195,9 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (um:when-let (blk (gethash id *blockchain-tbl*))
+      (um:when-let (blk (gethash (int id) *blockchain-tbl*))
         (acc blk)
-        (iter (int (block-prev-block-hash blk)))
+        (iter (block-prev-block-hash blk))
         ))))
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -150,11 +150,10 @@ THE SOFTWARE.
 
 (defmethod initialize-instance :after ((node node) &key &allow-other-keys)
   (when (null (node-blockchain node))
-    (let ((genesis-block (emotiq/config:get-genesis-block)))
-      (push genesis-block (node-blockchain node))
-      (setf (gethash (cosi/proofs:hash-block genesis-block)
-                     (node-blockchain-tbl node))
-            genesis-block))))
+    (let* ((genesis-block (emotiq/config:get-genesis-block))
+           (hashID        (hash-block genesis-block)))
+      (setf (node-blockchain node) hashID
+            (gethash hashID (node-blockchain-tbl node)) genesis-block))))
 
 ;; --------------------------------------------------------------
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -167,9 +167,9 @@ THE SOFTWARE.
   (and *blockchain*
        (gethash *blockchain* *blockchain-tbl*)))
 
-(defun block-list ()
+(defun block-list (&optional (from *blockchain*))
   (um:accum acc
-    (um:nlet-tail iter ((id *blockchain*))
+    (um:nlet-tail iter ((id from))
       (unless (null id)
         (let ((blk (gethash id *blockchain-tbl*)))
           (acc blk)

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,10 +195,11 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (um:when-let (blk (gethash (int id) *blockchain-tbl*))
-        (acc blk)
-        (iter (block-prev-block-hash blk))
-        ))))
+      (when id
+          (um:when-let (blk (gethash (int id) *blockchain-tbl*))
+            (acc blk)
+            (iter (block-prev-block-hash blk))
+            )))))
 
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -196,7 +196,9 @@ THE SOFTWARE.
   (um:accum acc
     (um:nlet-tail iter ((id from))
       (when id
+        ;; terminate on null reference (from genesis block)
           (um:when-let (blk (gethash (int id) *blockchain-tbl*))
+            ;; or terminate when missing the block
             (acc blk)
             (iter (block-prev-block-hash blk))
             )))))

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -68,9 +68,6 @@ THE SOFTWARE.
              :initform (make-subs))
    (bit      :accessor node-bit      ;; bit position in bitmap
              :initform 0)
-   (stake    :accessor node-stake
-             :initarg  :stake
-             :initform 0)
    ;; -------------------------------------
    ;; pseudo-globals per node
    (blockchain     :accessor node-blockchain

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,11 +195,10 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (unless (zerop id)
-        (let ((blk (gethash id *blockchain-tbl*)))
-          (acc blk)
-          (iter (int (block-prev-block-hash blk)))
-          )))))
+      (um:when-let (blk (gethash id *blockchain-tbl*))
+        (acc blk)
+        (iter (int (block-prev-block-hash blk)))
+        ))))
 
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -195,7 +195,7 @@ THE SOFTWARE.
 (defun block-list (&optional (from *blockchain*))
   (um:accum acc
     (um:nlet-tail iter ((id from))
-      (unless (null id)
+      (unless (zerop id)
         (let ((blk (gethash id *blockchain-tbl*)))
           (acc blk)
           (iter (int (block-prev-block-hash blk)))

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -76,8 +76,7 @@ THE SOFTWARE.
    (blockchain     :accessor node-blockchain
                    :initform nil)
    (blockchain-tbl :accessor node-blockchain-tbl
-                   :initform (make-hash-table
-                              :test 'equalp))
+                   :initform (make-hash-table))
    (mempool        :accessor  node-mempool
                    :initform  (make-hash-table
                                :test 'equalp))
@@ -161,6 +160,21 @@ THE SOFTWARE.
 
 (defun gen-uuid-int ()
   (uuid:uuid-to-integer (uuid:make-v1-uuid)))
+
+;; --------------------------------------------------------------
+
+(defun latest-block ()
+  (and *blockchain*
+       (gethash *blockchain* *blockchain-tbl*)))
+
+(defun block-list ()
+  (um:accum acc
+    (um:nlet-tail iter ((id *blockchain*))
+      (unless (null id)
+        (let ((blk (gethash id *blockchain-tbl*)))
+          (acc blk)
+          (iter (int (block-prev-block-hash blk)))
+          )))))
 
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -197,11 +197,13 @@ THE SOFTWARE.
     (um:nlet-tail iter ((id from))
       (when id
         ;; terminate on null reference (from genesis block)
-          (um:when-let (blk (gethash (int id) *blockchain-tbl*))
-            ;; or terminate when missing the block
-            (acc blk)
-            (iter (block-prev-block-hash blk))
-            )))))
+          (um:if-let (blk (gethash (int id) *blockchain-tbl*))
+            (progn
+              ;; or terminate when missing the block
+              (acc blk)
+              (iter (block-prev-block-hash blk)))
+            (warn "Missing block ~A -- you might want to ask for a back-fill" (short-id id)))
+          ))))
 
 
 

--- a/src/Cosi-BLS/cosi-construction.lisp
+++ b/src/Cosi-BLS/cosi-construction.lisp
@@ -206,5 +206,12 @@ THE SOFTWARE.
             (warn "Missing block ~A -- you might want to ask for a back-fill" (short-id id)))
           ))))
 
+(defmacro with-block-list ((blockchain-list) &body body)
+  `(let ((block-list (symbol-function 'cosi-simgen:block-list)))
+     (setf (symbol-function 'cosi-simgen:block-list)
+           (lambda () ,blockchain-list))
+     (multiple-value-prog1
+         (progn ,@body)
+       (setf (symbol-function 'cosi-simgen:block-list) block-list))))
 
 

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -245,7 +245,6 @@ THE SOFTWARE.
   (let* ((bits  (block-signature-bitmap blk))
          (pkey  (composite-pkey blk bits)))
     (and (int= blkID (hash-block blk))            ;; is it really the block I think it is?
-         (>= (logcount bits) (bft-threshold blk)) ;; does it have BFT thresh signatures?
          (check-block-multisignature blk)         ;; does the signature check out?
          )))
 
@@ -943,8 +942,10 @@ check that each TXIN and TXOUT is mathematically sound."
   (let* ((bits  (block-signature-bitmap blk))
          (sig   (block-signature blk))
          (hash  (hash/256 (signature-hash-message blk))))
-    (and (check-hash-multisig hash sig bits blk)
-         (check-block-transactions-hash blk))
+    (and (find (block-leader-pkey blk) (block-witnesses blk) ;; is the purported Leader in the witness list?
+               :test 'int=)
+         (check-hash-multisig hash sig bits blk)  ;; does the multisignature validate?
+         (check-block-transactions-hash blk))     ;; do the transactions hash to the header Merkel hash?
     ))
 
 (defun call-for-punishment ()

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -271,6 +271,9 @@ THE SOFTWARE.
                       (um:when-let (newID (block-prev-block-hash blk)) ;; do I have predecessor?
                         (assert (integerp newID))
                         (unless (gethash newID *blockchain-tbl*)
+                          ;; NOTE: While the following may appear to be a recursive call,
+                          ;; the semantics of ACTORS:RECV ensure that it performs in constant
+                          ;; stack space.
                           (sync-blockchain node newID))))  ;; if not, then ask for it
                      (t
                       ;; wasn't what I asked for, or invalid block response

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -217,7 +217,9 @@ THE SOFTWARE.
        (unless (find (node-pkey node) *dead-node-pkeys*
                      :test 'int=)
          ;;; Source of majority of messages on screen makes it fairly verbose
-         (pr "Cosi MSG: ~A" (mapcar 'short-id msg))
+         (pr "Cosi MSG: Node ~A ~A"
+             (short-id node)
+             (mapcar 'short-id msg))
          (um:dcase msg
            (:actor-callback (aid &rest ans)
             (let ((actor (lookup-actor-for-aid aid)))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -247,7 +247,6 @@ THE SOFTWARE.
          (pkey  (composite-pkey blk bits)))
     (and (int= blkID (hash-block blk))            ;; is it really the block I think it is?
          (>= (logcount bits) (bft-threshold blk)) ;; does it have BFT thresh signatures?
-         (int= pkey (composite-pkey blk bits))    ;; is the signature pkey properly formed?
          (pbc:check-hash blkid                    ;; does the signature check out?
                          (block-signature blk)
                          pkey)

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -197,6 +197,7 @@ THE SOFTWARE.
   (send-hold-election))     ;; b'cast to witness pool
 
 (defmethod node-dispatcher ((msg-sym (eql :blockchain-head)) &key pkey hashID sig)
+  (assert (integerp hashID))
   (unless (eql *blockchain* hashID)
     (pr "Missing block head ~A, requesting fill" hashID)
     (setf *blockchain* hashID)
@@ -245,6 +246,7 @@ THE SOFTWARE.
           )))))
 
 ;; -------------------------------------------------------------------------------------
+;; Blockchain Sync
 
 (defun ask-neighbor-node (&rest msg)
   (let* ((my-pkey (node-pkey (current-node)))
@@ -973,6 +975,10 @@ check that each TXIN and TXOUT is mathematically sound."
   (make-signed-message (make-blockchain-comment-message-skeleton pkey hashID)))
 
 (defun send-blockchain-comment ()
+  (pr "TEST - Blockchain = ~A" *blockchain*)
+  (inspect *blockchain*)
+  (assert (or (null *blockchain*)
+              (integerp *blockchain*)))
   (gossip:broadcast (make-signed-blockchain-comment-message (node-pkey (current-node))
                                                             *blockchain*)
                     :graphID :UBER))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -1,3 +1,4 @@
+;; cosi-handlers.lisp -- Cosi protocol handlers
 ;;
 ;; DM/Emotiq  02/18
 ;; ---------------------------------------------------------------

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -1,4 +1,3 @@
-
 ;;
 ;; DM/Emotiq  02/18
 ;; ---------------------------------------------------------------
@@ -247,9 +246,7 @@ THE SOFTWARE.
          (pkey  (composite-pkey blk bits)))
     (and (int= blkID (hash-block blk))            ;; is it really the block I think it is?
          (>= (logcount bits) (bft-threshold blk)) ;; does it have BFT thresh signatures?
-         (pbc:check-hash blkid                    ;; does the signature check out?
-                         (block-signature blk)
-                         pkey)
+         (check-block-multisignature blk)         ;; does the signature check out?
          )))
 
 (defun sync-blockchain (node hashID &optional (retries 1))

--- a/src/Cosi-BLS/cosi-handlers.lisp
+++ b/src/Cosi-BLS/cosi-handlers.lisp
@@ -174,8 +174,7 @@ THE SOFTWARE.
     (unless (eql *blockchain* hashID)
       (pr "Missing block head ~A, requesting fill" (short-id hashID))
       (setf *blockchain* hashID)
-      (spawn 'sync-blockchain (current-node) hashID))))
-
+      (start-backfill (current-node) hashID))))
 
 (defvar *max-query-depth*  8)
 
@@ -286,6 +285,16 @@ THE SOFTWARE.
             :TIMEOUT    timeout
             :ON-TIMEOUT (retry-ask)
             ))))))
+
+(defun start-backfill (node fromID)
+  ;; User callable backfill starter - need to provide a reference to
+  ;; the NODE structure to be backfilled, and a starting block ID hash
+  ;; value.
+  ;;
+  ;; If you received a warning about a missing block when calling
+  ;; (BLOCK-LIST) then the block ID you need is the prev-block-hash in
+  ;; the header of the last block in your returned list.
+  (spawn 'sync-blockchain node fromID))
 
 ;; --------------------------------------------------------------------
 

--- a/src/Cosi-BLS/cosi-netw-xlat.lisp
+++ b/src/Cosi-BLS/cosi-netw-xlat.lisp
@@ -92,14 +92,6 @@ THE SOFTWARE.
     (gossip-send pkey nil msg)))
         
 ;; --------------------------------------------------------------
-
-(defparameter *cosi-port*   65001)
-
-(defmethod translate-pkey-to-ip-port ((pkey pbc:public-key))
-  (let ((node (gethash (int pkey) *pkey-node-tbl*)))
-    (values (node-real-ip node) *cosi-port*)))
-
-;; --------------------------------------------------------------
 ;; THE SOCKET INTERFACE, TILL GOSSIP IS UP...
 ;; --------------------------------------------------------------
 
@@ -122,52 +114,4 @@ THE SOFTWARE.
       ;; return the contained message
       (pbc:signed-message-msg decoded))
     ))
-
-;; -----------------------------------------------------
-;; THE SOCKET INTERFACE...
-;; -----------------------------------------------------
-
-(defun port-routing-handler (buf)
-  (let ((packet (verify-hmac buf)))
-    (unless packet
-      (pr "Invalid packet"))
-    (when packet
-      ;; Every incoming packet is scrutinized for a valid HMAC. If
-      ;; it checks out then the packet is dispatched to an
-      ;; operation.  Otherwise it is just dropped on the floor.
-
-      ;; we can only arrive here if the incoming buffer held a valid
-      ;; packet
-      (progn ;; ignore-errors
-        ;; might not be a properly destructurable packet
-        (destructuring-bind (dest &rest msg) packet
-          (let ((node (gethash (int dest) *pkey-node-tbl*)))
-            (unless node
-              (pr :Non-existent-node))
-            (when node
-              (when (eq node *my-node*)
-                (pr (format nil "fowarding-by-default-to-me: ~A" msg)))
-              (apply 'ac:send (node-self node) msg)))))
-      )))
-
-(defvar *handler* (make-actor 'port-routing-handler))
-
-;;; For binary delivery, we need to allocate keypair memory at
-;;; runtime.
-(let ((hmac-keypair nil)
-      (hmac-keypair-mutex (mpcompat:make-lock)))
-  (defun hmac-keypair ()
-    (unless hmac-keypair
-      (mpcompat:with-lock (hmac-keypair-mutex)
-        (setf hmac-keypair
-              (pbc:make-key-pair (list :port-authority (uuid:make-v1-uuid))))))
-    hmac-keypair)
-  (defmethod socket-send (ip port dest msg)
-    (declare (ignore ip port))
-    (let* ((payload (make-hmac (list* dest msg)
-                               (pbc:keying-triple-pkey (hmac-keypair))
-                               (pbc:keying-triple-skey (hmac-keypair))))
-           (packet  (loenc:encode payload)))
-      (ac:send *handler* packet)
-      )))
 

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -338,7 +338,7 @@ based on their relative stake"
 
 (defmethod node-dispatcher ((msg-sym (eql :call-for-new-election)) &key pkey epoch sig)
   (when (and (validate-call-for-election-message pkey epoch sig) ;; valid call-for-election?
-             (or (pr "Got call for new election") t)
+             (or (pr "Node ~A got call for new election" (short-id (current-node))) t)
              (>= (length *election-calls*)
                 (bft-threshold (get-witness-list))))
     (run-special-election)))

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -227,9 +227,9 @@ based on their relative stake"
   (let ((self      (current-actor))
         (node      (current-node)))
     
-    (with-accessors ((pkey  node-pkey)) node
+    (with-accessors ((me  node-pkey)) node
 
-      (update-election-seed pkey)
+      (update-election-seed me)
 
       (let* ((winner     (hold-election n))
              (new-beacon (hold-election n (remove winner (emotiq/config:get-stakes)
@@ -243,18 +243,18 @@ based on their relative stake"
         
         (pr "~A got :hold-an-election ~A" (short-id node) n)
         (pr "election results ~A (stake = ~A)"
-                     (if (int= pkey winner) " *ME* " " not me ")
+                     (if (int= me winner) " *ME* " " not me ")
                      (stake-for winner))
         (pr "winner ~A me=~A"
                      (short-id winner)
-                     (short-id pkey))
+                     (short-id me))
 
-        (when (int= pkey new-beacon)
+        (when (int= me new-beacon)
           ;; launch a beacon
           (node-schedule-after *mvp-election-period*
             (send-hold-election)))
 
-        (cond ((int= pkey winner)
+        (cond ((int= me winner)
                ;; why not use ac:self-call?  A: Because doing it with
                ;; send, instead, allows queued up messages to be
                ;; handled first. Might be some transactions waiting to

--- a/src/Cosi-BLS/mvp-election-beacon.lisp
+++ b/src/Cosi-BLS/mvp-election-beacon.lisp
@@ -209,11 +209,10 @@ based on their relative stake"
    
 (defvar *mvp-election-period*  20) ;; seconds between election rounds
 
-(defun my-stake (node)
-  (let* ((pkey (node-pkey node))
-         (pair (find pkey (emotiq/config:get-stakes)
-                     :key  'first
-                     :test 'int=)))
+(defun stake-for (pkey)
+  (let ((pair (find pkey (emotiq/config:get-stakes)
+                    :key  'first
+                    :test 'int=)))
     (and pair
          (cadr pair))))
 
@@ -232,8 +231,7 @@ based on their relative stake"
 
       (update-election-seed pkey)
 
-      (let* ((stake      (my-stake node)) ;; used only for diagnostic display
-             (winner     (hold-election n))
+      (let* ((winner     (hold-election n))
              (new-beacon (hold-election n (remove winner (emotiq/config:get-stakes)
                                                   :key 'first
                                                   :test 'int=))))
@@ -246,7 +244,7 @@ based on their relative stake"
         (pr "~A got :hold-an-election ~A" (short-id node) n)
         (pr "election results ~A (stake = ~A)"
                      (if (int= pkey winner) " *ME* " " not me ")
-                     stake)
+                     (stake-for winner))
         (pr "winner ~A me=~A"
                      (short-id winner)
                      (short-id pkey))

--- a/src/Cosi-BLS/new-transactions.lisp
+++ b/src/Cosi-BLS/new-transactions.lisp
@@ -1056,7 +1056,7 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
    blocks of the blockchain (i.e., the value of cosi-simgen:*blockchain*)
    beginning the most recent minted and ending with the genesis block, with
    BLOCK-VAR bound during each iteration to the block."
-  `(loop for ,block-var in cosi-simgen:*blockchain*
+  `(loop for ,block-var in (cosi-simgen:block-list)
          do (progn ,@body)))
 
 (defmacro do-transactions ((tx-var blk) &body body)

--- a/src/Cosi-BLS/new-transactions.lisp
+++ b/src/Cosi-BLS/new-transactions.lisp
@@ -1798,3 +1798,4 @@ of type TYPE."
 ;; Modularity issue: note that this should not really "know" that
 ;; block-transactions is list. It is now specified as sequence, and it's left
 ;; open for it to become a merkle tree; clean up later!  -mhd, 6/20/18
+

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -333,6 +333,7 @@
    :latest-block
    :kill-node
    :enable-node
+   :start-backfill
    ))
 
 (defpackage :cosi-keying

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -329,6 +329,8 @@
    :set-nodes
    :get-witness-list
    :with-current-node
+   :block-list
+   :latest-block
    ))
 
 (defpackage :cosi-keying

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -331,6 +331,8 @@
    :with-current-node
    :block-list
    :latest-block
+   :kill-node
+   :enable-node
    ))
 
 (defpackage :cosi-keying

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -331,6 +331,7 @@
    :with-current-node
    :block-list
    :latest-block
+   :with-block-list
    :kill-node
    :enable-node
    :start-backfill

--- a/src/Cosi-BLS/test/tx-tests.lisp
+++ b/src/Cosi-BLS/test/tx-tests.lisp
@@ -33,7 +33,7 @@
   ;;     as the public key of the node, same as :public.
   ;;   :public - bignum representing public key of the node
   ;;   :private - bignum representing private key of the node
-  (let ((config-settings (emotiq/config:settings/read)))
+  (let ((config-settings (emotiq/config:setting)))
     (flet ((config-get (name) (cdr (assoc name config-settings))))
       (let* ((address-for-coin (config-get :address-for-coins))
              (public-key (config-get :public))

--- a/src/Crypto/crypto-pairings.asd
+++ b/src/Crypto/crypto-pairings.asd
@@ -30,11 +30,13 @@ THE SOFTWARE.
   :license     "Copyright (c) 2018 by Emotiq AG. All rights reserved."
   :serial       t
   :components  ((:file "pbc-cffi")
+                (:file "pbc")
                 (:file "subkey-derivation")
                 (:file "proofs"))
   :depends-on   ("core-crypto"
                  "emotiq"
                  "cffi"
+                 "useful-macros"
                  "crypto-pairings/libraries"))
 
 (defsystem "crypto-pairings/libraries"

--- a/src/Crypto/pbc-cffi.lisp
+++ b/src/Crypto/pbc-cffi.lisp
@@ -129,8 +129,10 @@ THE SOFTWARE.
    :*curve*
    :*curve-name*
    :*g1-zero*
-   :*g2-zero*
-   ))
+   :*g2-zero*)
+  (:export
+   :make-keying-triple
+   :make-keying-integers))
 
 (in-package :pbc-interface)
 

--- a/src/Crypto/pbc.lisp
+++ b/src/Crypto/pbc.lisp
@@ -1,0 +1,22 @@
+(in-package :pbc)
+
+(defun make-keying-triple (public-key secret-key &optional signature)
+  "Make a PBC:KEYING-TRIPLE from its integer representation of PUBLIC-KEY and SECRET-KEY"
+  (let* ((pkey (pbc:public-key public-key))
+         (skey (pbc:secret-key secret-key)))
+    (make-instance 'pbc:keying-triple
+                   :pkey pkey
+                   :skey skey
+                   :sig (or signature (pbc:sign-hash (hash:hash/256 pkey) skey)))))
+
+(defun make-keying-integers ()
+  "Makes a public/private keypair seeded via UUID:MAKE-V1-UUID
+
+Returns a list of of the generated public and private keys as integers"
+  (let ((keypair (pbc:make-key-pair (list :lisp-authority (uuid:make-v1-uuid)))))
+    (list
+     (vec-repr:int (pbc:keying-triple-pkey keypair))    ;; public is first
+     (vec-repr:int (pbc:keying-triple-skey keypair))))) ;; private is second
+
+
+

--- a/src/app.lisp
+++ b/src/app.lisp
@@ -15,8 +15,8 @@
 
 (defun get-nth-key (n)
   "return a keying triple from the config file for nth id"
-  (let ((public-private (nth n (gossip/config:get-values))))
-    (emotiq/config::make-keying-triple
+  (let ((public-private (nth n (emotiq/config:get-keypairs))))
+    (pbc:make-keying-triple
      (first public-private)
      (second public-private))))
 
@@ -56,6 +56,7 @@
     a))
 
 (defun app2 ()
+  #+(or)
   (wait-for-node-startup)
 
   (setf *genesis* (make-genesis-account))
@@ -266,12 +267,12 @@
 ; utxo-p
 ; find-tx
 
-
 (defun block-explorer ()
   (for-all-blocks (b)
      (for-all-transactions-in-block (tx b)
-        (explore-transaction (txid))))
+        (explore-transaction (txid)))))
 
+#+(or)
 (defun explore-transaction (txid)
   (let ((tx (cosi/proofs/newtx:find-tx txid)))
     (let ((from-list (get-transaction-tx-outs tx)))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,42 +1,64 @@
 (in-package :emotiq/config)
 
-(defun emotiq-conf ()
-  (make-pathname :defaults (emotiq/fs:etc/)
-                 :name "emotiq-conf"
+(defparameter *conf-filename*
+  (make-pathname :name "emotiq-conf"
                  :type "json"))
+(defparameter *hosts-filename*
+  (make-pathname :name "hosts"
+                 :type "conf"))
+(defparameter *local-machine-filename*
+  (make-pathname :name "local-machine"
+                 :type "conf"))
 
-(defun generated-directory (configuration)
-  (let ((host
-         (alexandria:assoc-value configuration :hostname))
-        (ip
-         (alexandria:assoc-value configuration :ip))
-        (gossip-server-port
-         (alexandria:assoc-value configuration :gossip-server-port))
-        (rest-server-port
-         (alexandria:assoc-value configuration :rest-server-port))
-        (websocket-server-port
-         (alexandria:assoc-value configuration :websocket-server-port)))
-    (make-pathname
-     :directory `(:relative
-                  ,(format nil "~{~a~^-~}"
-                           (list host ip gossip-server-port rest-server-port websocket-server-port))))))
+(defun settings (&key (root (emotiq/fs:etc/)))
+  (let ((p (merge-pathnames *conf-filename* root)))
+    (unless (probe-file p)
+      (emotiq:note "No configuration able to be read from '~a'" p)
+      (return-from settings nil))
+    (cl-json:decode-json-from-source p)))
+
+(defun setting (key &key (root (emotiq/fs:etc/)))
+  (let ((c (settings :root root)))
+    (alexandria:assoc-value c key)))
+
+(defun gossip-get-values (&key (root (emotiq/fs:etc/)))
+  "Return the values for the current network configuration.
+
+  The first value is the database of all keypairs in the test network.
+
+  The second value contains all hosts.
+
+  The third value contains the gossip local machine configuration of this node."
+  (handler-case
+      (let ((keypairs (get-keypairs :root root))
+            (hosts (read-pairs-database
+                    (merge-pathnames *hosts-filename* root)))
+            (gossip (read-gossip-configuration
+                     (merge-pathnames *local-machine-filename* root))))
+        (values
+         keypairs hosts gossip))
+    (error (e)
+      (emotiq:note "Configuration strategy failed because ~a" e)
+      nil)))
+
+(defun read-gossip-configuration (pathname)
+  (when (probe-file pathname)
+    (with-open-file (s pathname :direction :input :if-does-not-exist :error)
+      (let ((form (read s nil nil nil)))
+        form))))
 
 
-(defun settings/read (&optional key)
-  (unless (probe-file (emotiq-conf))
-    (emotiq:note "No configuration able to be read from '~a'" (emotiq-conf))
-    (return-from settings/read nil))
-  ;;; TODO: do gossip/configuration sequence
-  (let ((c (cl-json:decode-json-from-source (emotiq-conf))))
-    (if key
-        (alexandria:assoc-value c key)
-        c)))
+(defun local-machine (&key (root (emotiq/fs:etc/)))
+  (let ((form (with-open-file (o (merge-pathnames *local-machine-filename* root))
+                (read o))))
+    (destructuring-bind (&key eripa
+                              (gossip-port
+                               (emotiq/config:setting :gossip-server-port))
+                              pubkeys)
+        form
+      (values `(:eripa ,eripa :gossip-port ,gossip-port :pubkeys ,pubkeys)))))
 
-(defun make-keying-triple (pkey-bigint skey-bigint &optional signature)
-  (let* ((pkey (pbc:public-key pkey-bigint))
-         (skey (pbc:secret-key skey-bigint)))
-    (make-instance 'pbc:keying-triple
-                   :pkey pkey
-                   :skey skey
-                   :sig (or signature (pbc:sign-hash (hash:hash/256 pkey) skey)))))
+
+  
+  
 

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -108,20 +108,20 @@
                emotiq/logging
                emotiq/filesystem
                lisp-object-encoder
-               useful-macros
-               gossip/config)
-  :in-order-to ((test-op (test-op "emotiq-config-test")))
+               crypto-pairings
+               useful-macros)
   :components ((:module source
                 :pathname "./"
                 :serial t
                 :components ((:file "stakes")
-                             (:file "genesis")
-                             (:file "config")))))
+                             (:file "config")
+                             (:file "genesis")))))
+
 
 (defsystem "emotiq/config/generate"
   :depends-on (emotiq/config
                cosi-bls)
-  :in-order-to ((test-op (test-op "emotiq-config-test")))
+  :in-order-to ((test-op (test-op "test-generate")))
   :components ((:module source
                 :pathname "./"
                 :serial t

--- a/src/filesystem.lisp
+++ b/src/filesystem.lisp
@@ -73,3 +73,15 @@
     wallet))
 
 
+(defun new-temporary-directory (&key (root #p"/var/tmp/emotiq/"))
+  (loop
+     :with sub-directory = (make-pathname
+                            :defaults root
+                            :directory (append (pathname-directory root)
+                                               (list (symbol-name (gensym)))))
+     :until (not (probe-file sub-directory))
+     :finally (progn
+                (ensure-directories-exist sub-directory)
+                (return sub-directory))))
+       
+       

--- a/src/filesystem.lisp
+++ b/src/filesystem.lisp
@@ -75,7 +75,7 @@
 
 (defun new-temporary-directory (&key (root #p"/var/tmp/emotiq/"))
   (loop
-     :with sub-directory = (make-pathname
+     :for sub-directory = (make-pathname
                             :defaults root
                             :directory (append (pathname-directory root)
                                                (list (symbol-name (gensym)))))

--- a/src/genesis.lisp
+++ b/src/genesis.lisp
@@ -1,11 +1,13 @@
 (in-package :emotiq/config)
-(defun get-genesis-block (&key (configuration (settings/read)))
+
+(defun get-genesis-block (&key
+                            (configuration (settings))
+                            (root (emotiq/fs:etc/)))
   (let* ((genesis-block-file (alexandria:assoc-value configuration
                                                      :genesis-block-file))
          (p (make-pathname :name (pathname-name genesis-block-file)
                            :type "loenc"
-                           ;;; FIXME: a way to have more than one configuration
-                           :defaults (emotiq/fs:etc/))))
+                           :defaults root)))
     (with-open-file (o p
                      :element-type '(unsigned-byte 8)
                      :direction :input)

--- a/src/gossip/gossip.asd
+++ b/src/gossip/gossip.asd
@@ -4,7 +4,7 @@
   :author "Shannon Spires <svs@emotiq.ch>"
   :version "0.2.3"
   :maintainer "Shannon Spires <svs@emotiq.ch>"
-  :depends-on (gossip/config
+  :depends-on (emotiq/config
                emotiq/logging
                quicklisp
 	       uiop
@@ -12,8 +12,7 @@
                key-value-store
                actors
                crypto-pairings
-               usocket
-               illogical-pathnames)
+               usocket)
   :in-order-to ((test-op (test-op "gossip-test")))
   :serial t
   :components ((:file "package")
@@ -29,7 +28,10 @@
                (:file "http-fetch")
                (:file "graphviz")
                (:file "gossip-startup")))
+                      
 
+
+#+(or)
 (defsystem "gossip/config"
   :depends-on (emotiq/filesystem
                emotiq/logging

--- a/src/gossip/gossip.lisp
+++ b/src/gossip/gossip.lisp
@@ -41,8 +41,6 @@
   Should be true, especially on larger networks. Reduces unnecessary interim-replies while still ensuring
   some partial information is propagating in case of node failures.")
 
-(defparameter *nominal-gossip-port* 65002 "Nominal gossip network port to be used.")
-
 ;;;; DEPRECATE
 (defparameter *use-all-neighbors* 2 "True to broadcast to all neighbors; nil for none (no forwarding).
                                        Can be an integer to pick up to n neighbors.")
@@ -585,7 +583,9 @@ are in place between nodes.
 (defclass proxy-gossip-node (abstract-gossip-node actor-mixin)
   ((real-address :initarg :real-address :initform nil :accessor real-address
             :documentation "Real IP or DNS address of remote node")
-   (real-port :initarg :real-port :initform *nominal-gossip-port* :accessor real-port
+   (real-port :initarg :real-port
+              :initform (emotiq/config:setting :gossip-server-port)
+              :accessor real-port
               :documentation "Real port of remote node")
    (real-uid :initarg :real-uid :initform nil :accessor real-uid
                   :documentation "UID of the (real) gossip node on the other end.
@@ -2182,7 +2182,8 @@ gets sent back, and everything will be copacetic.
    again if you change the graph or want to start with a clean log."
   (when archive-log (archive-log))
   (sleep .5)
-  (start-gossip-transport usocket:*wildcard-host* *nominal-gossip-port*)
+  (start-gossip-transport usocket:*wildcard-host*
+                          (emotiq/config:setting :gossip-server-port))
   (maphash (lambda (uid node)
              (declare (ignore uid))
              (setf (car (ac::actor-busy (actor node))) nil)
@@ -2238,18 +2239,19 @@ gets sent back, and everything will be copacetic.
 
 (defun other-udp-port ()
   (when *udp-gossip-socket*
-    (if (= *nominal-gossip-port* *actual-udp-gossip-port*)
-        (1+ *nominal-gossip-port*)
-        *nominal-gossip-port*)))
+    (let ((gossip-port (emotiq/config:setting :gossip-server-port)))
+      (if (= gossip-port *actual-udp-gossip-port*)
+        (1+ gossip-port)
+        gossip-port))))
 
 (defun other-tcp-port ()
   "Deduce proper port for other end of connection based on whether this process
    has already established one. Only used for testing two processes communicating on one machine."
   (when *tcp-gossip-socket*
-    (if (= *nominal-gossip-port* *actual-tcp-gossip-port*)
-        (1+ *nominal-gossip-port*)
-        *nominal-gossip-port*)))
-
+    (let ((gossip-port (emotiq/config:setting :gossip-server-port)))
+      (if (= gossip-port *actual-tcp-gossip-port*)
+          (1+ gossip-port)
+          gossip-port))))
     
 ; UDP TESTS
 ; Test 1
@@ -2266,7 +2268,7 @@ gets sent back, and everything will be copacetic.
 #+TEST-LOCALHOST
 (setf rnode (ensure-proxy-node ':UDP "localhost" (other-udp-port) 200)) ; assumes there's a node numbered 200 on another Lisp process at 65003
 #+TEST-AMAZON
-(setf rnode (ensure-proxy-node ':UDP "ec2-35-157-133-208.eu-central-1.compute.amazonaws.com" *nominal-gossip-port* 200))
+(setf rnode (ensure-proxy-node ':UDP "ec2-35-157-133-208.eu-central-1.compute.amazonaws.com" (emotiq/config:setting :gossip-server-port 200)))
 
 
 #+TEST1 ; create 'real' local node to call solicit-wait on because otherwise system will try to forward the
@@ -2293,7 +2295,7 @@ gets sent back, and everything will be copacetic.
 #+TEST-LOCALHOST
 (setf rnode (ensure-proxy-node ':UDP "localhost" (other-udp-port) 0))
 #+TEST-AMAZON
-(setf rnode (ensure-proxy-node ':UDP "ec2-35-157-133-208.eu-central-1.compute.amazonaws.com" *nominal-gossip-port* 0))
+(setf rnode (ensure-proxy-node ':UDP "ec2-35-157-133-208.eu-central-1.compute.amazonaws.com" (emotiq/config:setting :gossip-server-port) 0))
 
 #+TEST2 ; create 'real' local node to call solicit-wait on because otherwise system will try to forward the
        ;   continuation that solicit-wait makes across the network
@@ -2321,7 +2323,7 @@ gets sent back, and everything will be copacetic.
 #+TEST-LOCALHOST
 (setf rnode (ensure-proxy-node ':TCP "localhost" (other-tcp-port) 0))
 #+TEST-AMAZON
-(setf rnode (ensure-proxy-node ':TCP "ec2-35-157-133-208.eu-central-1.compute.amazonaws.com" *nominal-gossip-port* 0))
+(setf rnode (ensure-proxy-node ':TCP "ec2-35-157-133-208.eu-central-1.compute.amazonaws.com" (emotiq/config:setting :gossip-server-port) 0))
 
 #+TEST3 ; create 'real' local node to call solicit-wait on because otherwise system will try to forward the
        ;   continuation that solicit-wait makes across the network

--- a/src/gossip/package.lisp
+++ b/src/gossip/package.lisp
@@ -8,7 +8,6 @@
    #:gossip-handler-case
    #:cosi-loaded-p
    #:initialize-node
-   #:*nominal-gossip-port*
    #:gossip-startup
    #:ping-other-machines
    #:*nodes*

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -104,6 +104,9 @@
   (:export
    #:*subpath*
    #:subpath
+
+   #:new-temporary-directory
+   
    #:emotiq/user/root/
    #:emotiq/wallet/
    #:tmp/
@@ -129,21 +132,39 @@
   (:use #:cl)
   (:export
    #:*nodes-dns-ip*
-   #:*stakes-filename*
    #:*max-stake*
-   #:emotiq-conf
+
+   #:*conf-filename*
+   #:*hosts-filename*
+   #:*local-machine-filename*
+   #:*stakes-filename*
+   #:*keypairs-filename*
+
    #:generated-directory
-   #:get-stakes
    #:get-genesis-block
-   #:settings/read))
+
+   #:gossip-get-values
+   
+   #:get-nth-key
+   #:get-stakes
+
+   #:get-keypairs
+   #:local-machine ;; aka gossip's idea of its configuration
+
+   #:settings
+   #:setting))
 
 (defpackage emotiq/config/generate
   (:use #:cl)
   (:export
    #:*dns-ip-zt.emotiq.ch*
-   #:keys/generate
-   #:stakes/generate
-   #:network/generate
+
+   #:+default-configuration+
+
+   #:generate-network
+   #:generate-keys
+   #:generate-stake
+
    #:ensure-defaults))
 
 (defpackage emotiq/app

--- a/src/stakes.lisp
+++ b/src/stakes.lisp
@@ -1,17 +1,48 @@
 (in-package :emotiq/config)
 
+;;;; HACK:  for true testnet this has to work without this file
+;;;;
+;;;; Configuration artifacts for test network as a whole
+;;;; Rename/repackage into emotiq/config/network
+
 (defparameter *stakes-filename*
   (make-pathname :name "stakes" :type "conf"))
 (defparameter *max-stake*
   (truncate (/ 1E9 1E3))  ;; ratio of total coins to stakers
   "Maximum amount to award a staked entity")
 
-(defun get-stakes ()
-  (let ((p (merge-pathnames *stakes-filename*
-                            (emotiq/fs:etc/))))
+(defun get-stakes (&key (root (emotiq/fs:etc/)))
+  (let ((p (merge-pathnames *stakes-filename* root)))
     (when (probe-file p)
       (with-open-file (o p
                          :direction :input)
-        (let ((*read-supress* t))
+        (let ((*read-suppress* t))
           (loop :with form
              :while (setf form (read o nil nil nil)) :collecting form))))))
+
+(defparameter *keypairs-filename*
+  (make-pathname :name "keypairs" :type "conf"))
+
+(defun read-pairs-database (pathname)
+  (unless (and pathname (probe-file pathname))
+    (emotiq:note "No pairs database found at '~a'" pathname)
+    (return-from read-pairs-database nil))
+  (with-open-file (s pathname)
+    (loop :for pair = (read s nil nil nil) 
+       :until (not pair)
+       :collect pair)))
+
+(defun get-keypairs (&key (root (emotiq/fs:etc/)))
+  (let ((pathname (merge-pathnames *keypairs-filename* root)))
+    (read-pairs-database pathname)))
+
+(defun get-nth-key (n
+                    &key (root (emotiq/fs:etc/)))
+  "Return the keying triple from the network configuration for Nth id"
+  (let ((public-private (nth n (get-keypairs :root root))))
+    (values 
+     (pbc:make-keying-triple
+      (first public-private)
+      (second public-private))
+     public-private)))
+

--- a/src/startup.lisp
+++ b/src/startup.lisp
@@ -24,22 +24,23 @@
 (in-package "EMOTIQ")
 
 ;; "Entry Point" for development - does nothing, just load and go
-(defun main (&key config-subpath how-started-message?)
-  (when config-subpath
-    (setf emotiq/fs:*subpath* config-subpath))
+(defun main (&key etc how-started-message?)
+  (when etc
+    (setf (symbol-function 'emotiq/fs:etc/)
+          (lambda () (pathname etc))))
   (message-running-state how-started-message?)
   ;; Create a default wallet on disk if one doesn't already exist
   (emotiq/wallet:create-wallet)
   ;; Start the websocket interface for the Electron wallet
   ;; listening <ws://localhost:PORT/wallet> .
   (when (string-equal "true"
-                      (emotiq/config:settings/read :websocket-server))
-    (websocket/wallet:start-server :port (emotiq/config:settings/read :websocket-server-port)))
+                      (emotiq/config:setting :websocket-server))
+    (websocket/wallet:start-server :port (emotiq/config:setting :websocket-server-port)))
   ;; Start the REST server which provides support for testing the
   ;; WebSocket implementation at <http://localhost:PORT/client/>
   (when (string-equal "true"
-                      (emotiq/config:settings/read :rest-server))
-    (emotiq-rest:start-server :port (emotiq/config:settings/read :rest-server-port)))
+                      (emotiq/config:setting :rest-server))
+    (emotiq-rest:start-server :port (emotiq/config:setting :rest-server-port)))
 
   (emotiq/tracker:start-tracker)
   (emotiq:start-node)

--- a/src/test/generate.lisp
+++ b/src/test/generate.lisp
@@ -1,4 +1,4 @@
-(in-package :emotiq-config-test)
+(in-package :emotiq-config-generate-test)
 
 ;;;; INTERNAL testing
 
@@ -6,7 +6,7 @@
 (define-test key-generation ()
   (let* ((devops-plist emotiq/config/generate:*dns-ip-zt.emotiq.ch*)
          (nodes-dns-ip devops-plist)
-         (nodes (emotiq/config/generate:keys/generate nodes-dns-ip)))
+         (nodes (emotiq/config/generate:generate-keys nodes-dns-ip)))
     (assert-eq (length devops-plist)
                (length nodes))))
 
@@ -16,7 +16,7 @@
 
 (define-test network-generation ()
    (let* ((devops-plist emotiq/config/generate:*dns-ip-zt.emotiq.ch*)
-          (directories (emotiq/config/generate:network/generate :nodes-dns-ip devops-plist)))
+          (directories (emotiq/config/generate:generate-network :nodes-dns-ip devops-plist)))
      (assert-eq (length devops-plist)
                 (length directories))))
 

--- a/src/test/genesis.lisp
+++ b/src/test/genesis.lisp
@@ -1,0 +1,48 @@
+(in-package :emotiq-config-generate-test)
+ 
+(defun create-genesis-block ()
+  (let ((directory
+         (emotiq/filesystem:new-temporary-directory)))
+    (let* ((nodes (emotiq/config/generate::generate-keys
+                   emotiq/config/generate::*dns-ip-zt.emotiq.ch*))
+           (stakes (emotiq/config/generate::generate-stakes
+                    (mapcar (lambda (plist)
+                              (getf plist :public))
+                            nodes)))
+           (configuration 
+            (emotiq/config/generate::make-configuration (first nodes) nodes stakes)))
+      (emotiq/config/generate::generate-node directory configuration
+                                             :key-records nodes)
+      (let* ((genesis-block
+              (emotiq/config:get-genesis-block
+               :configuration configuration
+               :root directory))
+             (keypair
+              (emotiq/config:get-nth-key 0 :root directory)))
+        (values
+         (cosi-simgen:with-block-list ((list genesis-block))
+           (cosi/proofs/newtx:get-balance (emotiq/txn:address keypair)))
+         directory)))))
+
+(defun verify-genesis-block (&key (root (emotiq/fs:etc/)))
+  (let* ((genesis-block
+          (emotiq/config:get-genesis-block
+           :configuration (emotiq/config:settings :root root)
+           :root root))
+         (keypair
+          (emotiq/config:get-nth-key 0 :root root)))
+    (values
+     (cosi-simgen:with-block-list ((list genesis-block))
+       (cosi/proofs/newtx:get-balance (emotiq/txn:address keypair)))
+     root)))
+
+(define-test genesis-block ()
+   (multiple-value-bind (coinbase-amount directory)
+       (create-genesis-block)
+     (assert-true (equal coinbase-amount
+                         (cosi/proofs/newtx:initial-total-coin-amount)))))
+
+
+
+
+  

--- a/src/test/package.lisp
+++ b/src/test/package.lisp
@@ -2,7 +2,7 @@
   (:use #:cl #:emotiq #:lisp-unit)
   (:export test-blockchain))
 
-(defpackage #:emotiq-config-test
+(defpackage #:emotiq-config-generate-test
   (:use #:cl #:emotiq #:lisp-unit))
 
 (defpackage #:emotiq-sim-test

--- a/src/test/test-generate.asd
+++ b/src/test/test-generate.asd
@@ -1,17 +1,19 @@
-(defsystem "emotiq-config-test"
+(defsystem "test-generate"
   :version "0.1.0"
   :description "Emotiq"
   :author "Copyright (c) 2018 Emotiq AG"
   :license "MIT (see LICENSE.txt)"
   :depends-on (lisp-unit
+               emotiq/txn
                emotiq/config/generate)
   :perform (test-op (o s)
                     (symbol-call :lisp-unit :run-tests
-                                 :all :emotiq-config-test))
+                                 :all :emotiq-config-generate-test))
   :components ((:module package
                 :pathname "./"
                 :components ((:file "package")))
                (:module tests
                 :depends-on (package)
                 :pathname "./"
-                :components ((:file "emotiq-config")))))
+                :components ((:file "genesis")
+                             (:file "generate")))))

--- a/src/txn.lisp
+++ b/src/txn.lisp
@@ -132,7 +132,7 @@
 ;;   ;;     as the public key of the node, same as :public.
 ;;   ;;   :public - bignum representing public key of the node
 ;;   ;;   :private - bignum representing private key of the node
-;;   (let ((config-settings (emotiq/config:settings/read)))
+;;   (let ((config-settings (emotiq/config:setting/read)))
 ;;     (flet ((config-get (name) (cdr (assoc name config-settings))))
 ;;       (let* ((address-for-coin (config-get :address-for-coins))
 ;;              (public-key (config-get :public))


### PR DESCRIPTION
forcibly set *CURRENT-NODE* when new Node is constructed. For sanity sake. It will make node context equal to the last node ever constructed by default. But on a single NODE machine, as in AWS, it will allow for REPL interactions without needing to specify WITH-CURRENT-NODE. However, WITH-CURRENT-NODE will override context when necessary, as always before.