### PR TITLE
init-pairing added to emotiq:start

### DIFF
--- a/src/startup.lisp
+++ b/src/startup.lisp
@@ -59,6 +59,7 @@
   (unintern 'cl-user::*performing-binary-build*) ;; if building binary,
   (setq *production* t)  ;; used by EMOTIQ:PRODUCTION-P in Crypto
   (message-running-state "from command line")
+  (pbc:init-pairing)
   (actors:install-actor-system)
   (main))
 


### PR DESCRIPTION
This appears to fix issue #385 - pbc:init-pairings needs to be called during startup of binary