### PR TITLE
Dev cleanups 20180802a

### DIFF
--- a/etc/all-tests.sexp
+++ b/etc/all-tests.sexp
@@ -3,6 +3,7 @@
  :crypto-pairings-test
  :cosi-bls-test
  :wallet-test
+ :core-crypto-test
  :test-generate)
  
 

--- a/src/Crypto/core-crypto.asd
+++ b/src/Crypto/core-crypto.asd
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 (asdf:defsystem "core-crypto"
   :description "core-crypto: core cryptography functions"
-  :version     "1.0"
+  :version     "1.0.1"
   :author      "D.McClain <dbm@refined-audiometrics.com>"
   :license     "Copyright (c) 2015 by Refined Audiometrics Laboratory, LLC. All rights reserved."
   :components  ((:file "ecc-package")
@@ -46,6 +46,7 @@ THE SOFTWARE.
                 (:file "crypto-environ")
                 #+:COM.RAL (:file "machine-id")
                 (:file "lagrange-4-square"))
+  :in-order-to ((test-op (test-op "core-crypto-test")))
   :serial       t
   :depends-on   ("ironclad"
                  #+:COM.RAL "aesx"
@@ -54,6 +55,5 @@ THE SOFTWARE.
                  "lisp-object-encoder"
                  "s-base64"
                  "emotiq"
-                 "emotiq/delivery"
-                 ))
+                 "emotiq/delivery"))
 

--- a/src/Crypto/test/core-crypto-test.asd
+++ b/src/Crypto/test/core-crypto-test.asd
@@ -1,14 +1,16 @@
-(defsystem "crypto-pairings-test"
+(defsystem "core-crypto-test"
   :depends-on (crypto-pairings
                lisp-unit)
   :perform (test-op (o s)
              (symbol-call :lisp-unit :run-tests
-                          :all :crypto-pairings-test))
+                          :all :core-crypto-test))
   :components ((:module package
                 :pathname "./"
                 :components ((:file "package")))
                (:module tests
                 :depends-on (package)
                 :pathname "./"
-                :components ((:file "hash")
-                             (:file "crypto-pairings-test")))))
+                :components ((:file "hash")))))
+
+
+                       

--- a/src/Crypto/test/crypto-pairings-test.lisp
+++ b/src/Crypto/test/crypto-pairings-test.lisp
@@ -1,4 +1,3 @@
-
 (in-package :crypto-pairings-test)
 
 (define-test basis-consistency
@@ -94,48 +93,3 @@
 
 
 
-;;;; Base58 Tests
-
-;;; Adapted from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
-
-(defparameter *base58-test-inputs-and-expected-outputs*
-  '(("" "")
-    ("61" "2g")
-    ("626262" "a3gV")
-    ("636363" "aPEr")
-    ("73696d706c792061206c6f6e6720737472696e67" "2cFupjhnEsSn59qHXstmK2ffpLv2")
-    ("00eb15231dfceb60925886b67d065299925915aeb172c06647" "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L")
-    ("516b6fcd0f" "ABnLTmg")
-    ("bf4f89001e670274dd" "3SEo3LWLoPntC")
-    ("572e4794" "3EFU7m")
-    ("ecac89cad93923c02321" "EJDM8drfXA6uyA")
-    ("10c8511e" "Rt5zm")
-    ("00000000000000000000" "1111111111")
-    ("000111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5" "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
-    ("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff" "1cWB5HCBdLjAuqGGReWE3R3CguuwSjw6RHn39s2yuDRTS5NsBgNiFpWgAnEx6VQi8csexkgYw3mdYrMHr8x9i7aEwP8kZ7vccXWqKDvGv3u1GxFKPuAkn8JCPPGDMf3vMMnbzm6Nh9zh1gcNsMvH3ZNLmP5fSG6DGbbi2tuwMWPthr4boWwCxf7ewSgNQeacyozhKDDQQ1qL5fQFUW52QKUZDZ5fw3KXNQJMcNTcaB723LchjeKun7MuGW5qyCBZYzA1KjofN1gYBV3NqyhQJ3Ns746GNuf9N2pQPmHz4xpnSrrfCvy6TVVz5d4PdrjeshsWQwpZsZGzvbdAdN8MKV5QsBDY")))
-
-(setq lisp-unit:*print-failures* t)     ; <= consider removing or move
-                                        ; elsewhere when dust settles?
-                                        ; -mhd, 5/29/18
-
-(defun base58-tests ()
-  (loop for (in-hex-string expected-out-base58-string)
-          in *base58-test-inputs-and-expected-outputs*
-        as in-bv = (ironclad:hex-string-to-byte-array in-hex-string)
-        as out-base58-string = (vec-repr:base58-str in-bv)
-        initially (format t "~%Base58-test~%")
-        do (format t "In: ~s~%  => (expect:) ~s~%" 
-                   in-hex-string expected-out-base58-string)
-           ;; make less verbose after the dust settles! -mhd, 5/29/18
-           (unless (equal out-base58-string 
-                          expected-out-base58-string)
-             (cerror "Continue as usual"
-                     "Unexpected results.~%   ~s => ~s~%  Expected: ~s."
-                     in-hex-string out-base58-string
-                     expected-out-base58-string))
-           (assert-equal out-base58-string 
-                         expected-out-base58-string)))
-
-
-(define-test base58-tests
-  (base58-tests))

--- a/src/Crypto/test/hash.lisp
+++ b/src/Crypto/test/hash.lisp
@@ -1,0 +1,53 @@
+(in-package :core-crypto-test)
+
+(define-test base58 ()
+  (let ((iterations 100))
+    (loop
+       :repeat iterations
+       :doing (let* ((val (random (ash 1 256)))
+                     (b58  (vec-repr:base58-str val))
+                     (b582 (vec-repr:base58-str val)))
+                (assert-true (string= b58 b582))))))
+
+;;;; Base58 Tests
+
+;;; Adapted from https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
+
+(defparameter *base58-test-inputs-and-expected-outputs*
+  '(("" "")
+    ("61" "2g")
+    ("626262" "a3gV")
+    ("636363" "aPEr")
+    ("73696d706c792061206c6f6e6720737472696e67" "2cFupjhnEsSn59qHXstmK2ffpLv2")
+    ("00eb15231dfceb60925886b67d065299925915aeb172c06647" "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L")
+    ("516b6fcd0f" "ABnLTmg")
+    ("bf4f89001e670274dd" "3SEo3LWLoPntC")
+    ("572e4794" "3EFU7m")
+    ("ecac89cad93923c02321" "EJDM8drfXA6uyA")
+    ("10c8511e" "Rt5zm")
+    ("00000000000000000000" "1111111111")
+    ("000111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5" "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
+    ("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff" "1cWB5HCBdLjAuqGGReWE3R3CguuwSjw6RHn39s2yuDRTS5NsBgNiFpWgAnEx6VQi8csexkgYw3mdYrMHr8x9i7aEwP8kZ7vccXWqKDvGv3u1GxFKPuAkn8JCPPGDMf3vMMnbzm6Nh9zh1gcNsMvH3ZNLmP5fSG6DGbbi2tuwMWPthr4boWwCxf7ewSgNQeacyozhKDDQQ1qL5fQFUW52QKUZDZ5fw3KXNQJMcNTcaB723LchjeKun7MuGW5qyCBZYzA1KjofN1gYBV3NqyhQJ3Ns746GNuf9N2pQPmHz4xpnSrrfCvy6TVVz5d4PdrjeshsWQwpZsZGzvbdAdN8MKV5QsBDY")))
+
+(defun base58-tests ()
+  (loop for (in-hex-string expected-out-base58-string)
+          in *base58-test-inputs-and-expected-outputs*
+        as in-bv = (ironclad:hex-string-to-byte-array in-hex-string)
+        as out-base58-string = (vec-repr:base58-str in-bv)
+        initially (format t "~%Base58-test~%")
+        do (format t "In: ~s~%  => (expect:) ~s~%" 
+                   in-hex-string expected-out-base58-string)
+           ;; make less verbose after the dust settles! -mhd, 5/29/18
+           (unless (equal out-base58-string 
+                          expected-out-base58-string)
+             (cerror "Continue as usual"
+                     "Unexpected results.~%   ~s => ~s~%  Expected: ~s."
+                     in-hex-string out-base58-string
+                     expected-out-base58-string))
+           (assert-equal out-base58-string 
+                         expected-out-base58-string)))
+
+(define-test base58-tests
+  (base58-tests))
+
+

--- a/src/Crypto/test/package.lisp
+++ b/src/Crypto/test/package.lisp
@@ -1,4 +1,3 @@
-
 (defpackage :crypto-pairings-test
   (:nicknames :pbc-test)
   (:use :cl
@@ -6,4 +5,9 @@
    :hash
    :pbc
    :subkey-derivation
+   :lisp-unit))
+
+(defpackage :core-crypto-test
+  (:nicknames :test-core-crypto)
+  (:use :cl
    :lisp-unit))

--- a/src/test/verify-genesis-block.lisp
+++ b/src/test/verify-genesis-block.lisp
@@ -1,36 +1,39 @@
 (in-package :emotiq-config-generate-test)
 
 (defun create-and-check-genesis-block ()
-  (let ((d (emotiq/filesystem:new-temporary-directory)))
-    (let* ((nodes
-            (emotiq/config/generate::generate-keys
-             '((:hostname "127.0.0.1" :ip "127.0.0.1"))))
-           (stakes
-            (emotiq/config/generate::generate-stakes
-             (mapcar (lambda (plist)
-                       (getf plist :public))
-                     nodes)))
-           (address-for-coins
-            (getf (first nodes) :public))
-           (keypair (pbc:make-keying-triple (getf (first nodes) :public) (getf (first nodes) :private)))
-           (genesis-block              
-              (cosi/proofs:create-genesis-block address-for-coins stakes
-              )))
-        (values
-         (cosi-simgen:with-block-list ((list genesis-block))
-           (cosi/proofs/newtx:get-balance (emotiq/txn:address keypair)))
-         d))))
+  (let* ((nodes
+          (emotiq/config/generate::generate-keys
+           '((:hostname "127.0.0.1" :ip "127.0.0.1"))))
+         (stakes
+          (emotiq/config/generate::generate-stakes
+           (mapcar (lambda (plist)
+                     (getf plist :public))
+                   nodes)))
+         (coinbase-pkey-as-integer
+          (getf (first nodes) :public))
+         (coinbase-keypair
+          (pbc:make-keying-triple
+           (getf (first nodes) :public)
+           (getf (first nodes) :private)))
+         (genesis-block              
+          (cosi/proofs:create-genesis-block coinbase-pkey-as-integer stakes)))
+    (values
+     (cosi-simgen:with-block-list ((list genesis-block))
+       (cosi/proofs/newtx:get-balance (emotiq/txn:address coinbase-keypair)))
+     coinbase-keypair
+     coinbase-pkey-as-integer)))
 
 (define-test verify-genesis-block-generate ()
-  (progn 
-    (emotiq:note "Generating 100 genesis blocks~%")
+  (let ((iterations 100))
+    (emotiq:note "Generating ~a genesis blocks" iterations)
     (loop
-      :repeat 100
+      :repeat iterations
       :do (progn
-            (multiple-value-bind (amount directory)
+            (multiple-value-bind (amount coinbase-keypair coinbase-public-address)
                 (create-and-check-genesis-block)
+              (assert-true (equal (vec-repr:int (pbc:keying-triple-pkey coinbase-keypair))
+                                  coinbase-public-address))
               (assert-true (equal amount
                                   (cosi/proofs/newtx:initial-total-coin-amount))))
-            (format t "."))
-    ))
-)
+            (format t ".")))))
+

--- a/src/txn.lisp
+++ b/src/txn.lisp
@@ -3,11 +3,12 @@
 (defparameter *transaction-fee* 10)
 
 ;;;; ADDRESS method could ideally be placed in EMOTIQ or EMOTIQ/USER package?
-(defmethod address ((account pbc:keying-triple))
-  (address (pbc:keying-triple-pkey account)))
 (defmethod address ((pkey pbc:public-key))
   (cosi/proofs:public-key-to-address pkey))
-
+(defmethod address ((account pbc:keying-triple))
+  (address (pbc:keying-triple-pkey account)))
+(defmethod address ((integers cons))
+  (address (pbc:make-keying-triple (first integers) (second integers))))
 
 (defmethod get-utxos ((account pbc:keying-triple))
   (get-utxos (address account)))


### PR DESCRIPTION
Missing progress from fixing genesis block creation

1.  EMOTIQ/TXN:ADDRESS now works on keypairs expressed as integer pairs

2.  Moved hash tests into new `core-crypto-test` suite, including a version of David's test

3.  Cleanups to `test-generate`