### PR TITLE
fixed bug in select-inputs ; error was always being signalled

### DIFF
--- a/src/txn.lisp
+++ b/src/txn.lisp
@@ -77,8 +77,11 @@
          :do (incf selected-amount tx-amount)
          :do (push txn-spec selected-txns)
          :do (cond ((= selected-amount amount) (exact))
-                   ((> selected-amount amount) (surplus))))
-      (error "insufficient funds ~A" selected-txns))))
+                   ((> selected-amount amount) (surplus))
+                   (t (error "insufficient funds for txamount ~A~%~tselected amount ~A~%~tselected transactions ~A"
+                             tx-amount
+                             selected-amount 
+                             selected-txns)))))))
 
 
 


### PR DESCRIPTION
the error statement at the end of select-inputs was always signalled, moved it inside the cond and added more info on output