### PR TITLE
revert select-inputs

### DIFF
--- a/src/txn.lisp
+++ b/src/txn.lisp
@@ -77,12 +77,8 @@
          :do (incf selected-amount tx-amount)
          :do (push txn-spec selected-txns)
          :do (cond ((= selected-amount amount) (exact))
-                   ((> selected-amount amount) (surplus))
-                   (t (error "insufficient funds for txamount ~A~%~tselected amount ~A~%~tselected transactions ~A"
-                             tx-amount
-                             selected-amount 
-                             selected-txns)))))))
-
+                   ((> selected-amount amount) (surplus))))
+      (error "insufficient funds in txns=~A for amount=~A" selected-txns amount))))
 
 
 ;; UTXOS: (list (TXO (TxID INDEX) AMT) ...)


### PR DESCRIPTION
KS should probably approve this un-change.

I've included other reviewers so that they remain in the loop.

My earlier fix to select-inputs needs to be reverted - the COND calls FLETs that contain RETURN-FROMs.  If the loop ever finishes, it should raise an error.

I've added one more piece of info to the error message.

[We / I need to add unit tests for generating transactions and for raising the error (3 tests? exact, surplus and error).  Parts of emotiq/app (still in development) might be used for such tests.  Code that creates transactions might need to SLEEP to have the transactions propagate.  Can this be circumvented / synchronized in the CI tests?  e.g. the Leader knows what the blockchain is after a successful commit (of all of the transactions).]