### PR TITLE
fix issue 422 - error if config has not been run

### DIFF
--- a/src/stakes.lisp
+++ b/src/stakes.lisp
@@ -39,6 +39,12 @@
                     &key (root (emotiq/fs:etc/)))
   "Return the keying triple from the network configuration for Nth id"
   (let ((public-private (nth n (get-keypairs :root root))))
+    (when (or (null (first public-private))
+              (null (second public-private)))
+      ;; this is really an error - developer forgot to run config
+      (error (format nil "get-nth-key sees NIL in [~a,~a] (has the config been run?)~%e.g. (emotiq/config/generate:ensure-defaults :force t :for-purely-local t)~%"
+                     (first public-private)
+                     (second public-private))))
     (values 
      (pbc:make-keying-triple
       (first public-private)


### PR DESCRIPTION
Closes #422 

Just an error message added to remind developers to generate a config, if they've forgotten.
