### PR TITLE
Introduced structured logging.

### DIFF
--- a/src/app-get-transactions.lisp
+++ b/src/app-get-transactions.lisp
@@ -10,12 +10,12 @@
           (when (or (eq :COLLECT (cosi/proofs/newtx::transaction-type tx))
                     (eq :SPEND (cosi/proofs/newtx::transaction-type tx)))
             (dolist (out (cosi/proofs/newtx::transaction-outputs tx)) 
-              #+nil-might-help-with-debug(emotiq:note "comparing ~a [~a] account-address ~a to transaction-output ~a -> ~a"
-                           (account-name a)
-                           (emotiq/txn:address (account-triple a))
-                           account-address
-                           (cosi/proofs/newtx::tx-out-public-key-hash out)
-                           (cosi/proofs/newtx::account-addresses= account-address (cosi/proofs/newtx::tx-out-public-key-hash out)))
+              #+nil-might-help-with-debug(log-debug "comparing account-address to transaction-output"
+                      :data `(:account-name ,(account-name a)
+                              :account-address-from-triple ,(emotiq/txn:address (account-triple a))
+                              :account-address-from-pkey ,account-address
+                              :account-address-from-tx ,(cosi/proofs/newtx::tx-out-public-key-hash out)
+                              :result ,(cosi/proofs/newtx::account-addresses= account-address (cosi/proofs/newtx::tx-out-public-key-hash out))))
               (when (cosi/proofs/newtx::account-addresses= account-address (cosi/proofs/newtx::tx-out-public-key-hash out))
                 (push tx result)))))))
     result))

--- a/src/app.lisp
+++ b/src/app.lisp
@@ -77,7 +77,7 @@
   "entry point for tests"
   (let ((strm emotiq:*notestream*))
     (emotiq:main :etc-and-wallets etc-and-wallets)
-    (setf gossip::*debug-level* nil)
+    ;; (setf gossip::*debug-level* nil)
     (app)
     (setq *node* cosi-simgen::*my-node*  ;; for debugging
            *blocks* (cosi-simgen::block-list))
@@ -94,8 +94,8 @@
 
   (let ((bal (get-balance *genesis*))
         (a (emotiq/txn:address (account-triple *genesis*))))
-    (emotiq:note "balance for genesis is ~A" bal)
-    (emotiq:note "address of genesis ~A" a))
+    (log-info "balance for genesis" :data `(:balance ,bal))
+    (log-info "address of genesis" :data `(:address ,a)))
   
   (setf *alice* (make-account "alice")
 	*bob* (make-account "bob")
@@ -164,7 +164,7 @@
                amount
                :fee fee)))
      (publish-transaction txn)
-     (emotiq:note "sleeping to let txn propagate (is this necessary?)")
+     (log-info "sleeping to let txn propagate (is this necessary?)")
      (sleep 30)
      txn)))
   
@@ -180,7 +180,7 @@
 (defun dump-results (strm)
 
   (let ((bal-genesis (get-balance (get-genesis-key))))
-    (emotiq:note"genesis balance(~a)~%" bal-genesis))
+    (log-info "genesis balance" :data `(:balance ,bal-genesis)))
 
   #+nil(let ((bal-alice (get-balance *alice*))
         (bal-bob   (get-balance *bob*))
@@ -189,8 +189,10 @@
     (with-current-node
      (setf emotiq:*notestream* *standard-output*)
      (cosi/proofs/newtx:dump-txs :blockchain t)
-     (emotiq:note "")
-     (emotiq:note "balances alice(~a) bob(~a) mary(~a) james(~a)~%" bal-alice bal-bob bal-mary bal-james)
+     (log-info "balance for alice" :data `(:balance ,bal-alice))
+     (log-info "balance for bob" :data `(:balance ,bal-bob))
+     (log-info "balance for mary" :data `(:balance ,bal-mary))
+     (log-info "balance for james" :data `(:balance ,bal-james))
      (dumpamounts)
      
      ;; this gathers all txns to alice/bob/mary/james (incl. change txns)
@@ -198,11 +200,10 @@
            (tx-bob (get-all-transactions-to-given-target-account *bob*))
            (tx-mary (get-all-transactions-to-given-target-account *mary*))
            (tx-james (get-all-transactions-to-given-target-account *james*)))
-       (emotiq:note "transactions-to~%alice ~A~%bob ~A~%mary ~A~%james ~A~%"
-                    tx-alice
-                    tx-bob
-                    tx-mary
-                    tx-james)
+       (log-info "transactions for alice" :data `(:transactions ,tx-alice))
+       (log-info "transactions for bob" :data `(:transactions ,tx-bob))
+       (log-info "transactions for mary" :data `(:transactions ,tx-mary))
+       (log-info "transactions for james" :data `(:transactions ,tx-james))
        
        (setf emotiq:*notestream* strm)
        (values)))))
@@ -212,8 +213,10 @@
         (bobamount  (- 490 300))
         (maryamount (+ 290 190))
         (jamesamount 90))
-    (emotiq:note "calculated balances alice(~a) bob(~a) mary(~a) james(~a)~%"
-                 aliceamount bobamount maryamount jamesamount)))
+    (log-info "calculatred balance for alice" :data `(:balance ,aliceamount))
+    (log-info "calculatred balance for bob" :data `(:balance ,bobamount))
+    (log-info "calculatred balance for mary" :data `(:balance ,maryamount))
+    (log-info "calculatred balance for james" :data `(:balance ,jamesamount))))
     
 (defun dtx ()
   (with-current-node

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -16,7 +16,7 @@
 (defun settings (&key (root (emotiq/fs:etc/)))
   (let ((p (merge-pathnames *conf-filename* root)))
     (unless (probe-file p)
-      (emotiq:note "No configuration able to be read from '~a'" p)
+      (emotiq:s-note "No configuration able to be read!" :data `(:path ,p) :subsystem :emotiq/conf)
       (return-from settings nil))
     (cl-json:decode-json-from-source p)))
 
@@ -41,7 +41,7 @@
         (values
          keypairs hosts gossip))
     (error (e)
-      (emotiq:note "Configuration strategy failed because ~a" e)
+      (emotiq:s-note "Configuration strategy failed!" :data `(:error ,e))
       nil)))
 
 (defun read-gossip-configuration (pathname)

--- a/src/emotiq.asd
+++ b/src/emotiq.asd
@@ -15,6 +15,8 @@
 
 (defsystem "emotiq/logging"
   :depends-on (emotiq
+               alexandria
+               cl-json
                simple-date-time)
   :components ((:file "note")))
 

--- a/src/gossip/logging.lisp
+++ b/src/gossip/logging.lisp
@@ -186,7 +186,8 @@
           ;; First object in logmsg is the timestamp.
           ;;
           ;; TODO: use the timestamp directly. It's (car logmsg).
-          (emotiq:note "~{~a~^ ~}" (cdr logmsg)))
+          (let ((msg (format nil "~{~a~^ ~}" (cdr logmsg))))
+            (emotiq:s-note msg :level :info :subsystem :emotiq/gossip)))
     (:quit (ac:become 'ac:do-nothing))
           
     ; :save saves current log to files without modifying it

--- a/src/note.lisp
+++ b/src/note.lisp
@@ -6,19 +6,27 @@
 ;;; N.b. deliberately not a macro so we can theoretically inspect the
 ;;; call stack.
 
-(defun timestring ()
-  "Return a string representing current time"
-  (let ((formats '(simple-date-time:|yyyymmddThhmmssZ|
-                   simple-date-time:|yyyy-mm-dd hh:mm:ss|)))
-    (apply (second formats)
-           (list (simple-date-time:now)))))
+(defun logevent (msg &key (level :info) (subsystem :top) data)
+  (let ((d (alexandria:plist-alist data)))
+    (setf (alexandria:assoc-value d :timestamp) (simple-date-time:now))
+    (setf (alexandria:assoc-value d :level) level)
+    (setf (alexandria:assoc-value d :msg) msg)
+    (setf (alexandria:assoc-value d :subsystem) subsystem)
+    d))
 
-(defun %prefixed-note (prefix message-or-format &rest args)
-  (when *notestream*
-    (let ((timestamped (concatenate 'string "~%" (timestring) prefix message-or-format)))
-      ; following because some format control strings like ~& throw errors on
-      ;   some kinds of *notestream*, e.g. those created by #'make-log-window
-      (write-string (apply #'format nil timestamped args) *notestream*))))
+(defun logevent-to-string (event)
+  (let ((prefix-with-msg (format nil "~&~A ~A ~A msg: ~A" 
+                        (simple-date-time:|yyyy-mm-dd hh:mm:ss| (alexandria:assoc-value event :timestamp))
+                        (string (alexandria:assoc-value event :level))
+                        (string (alexandria:assoc-value event :subsystem))
+                        (alexandria:assoc-value event :msg)))
+        (stripped-data (alexandria:remove-from-plist (alexandria:alist-plist event) :level :msg :subsystem :timestamp)))
+      (if stripped-data
+          (format nil "~A | ~{~a: ~a~^, ~}~%" prefix-with-msg stripped-data)
+          (format nil "~A~%" prefix-with-msg))))
+
+(defun logevent-to-json (event)
+  (cl-json:encode-json-alist-to-string event))
 
 ;;; Do NOT call the following with leading or trailing newlines
 ;;;  in message-or-format. They will be added automatically.
@@ -26,7 +34,10 @@
   "Emit a note of progress to the appropiate logging system
 MESSAGE-OR-FORMAT is either a simple string containing a message, or
 a CL:FORMAT control string referencing the values contained in ARGS."
-  (apply #'%prefixed-note " " message-or-format args))
+  (let* ((msg (apply #'format nil message-or-format args))
+        (evt (logevent msg :level :info :subsystem :unknown)))
+      (write-string (logevent-to-string evt) *notestream*)
+    ))
 
 (eval-when (:load-toplevel)
   ;; hook, even if Actors isn't loaded...

--- a/src/note.lisp
+++ b/src/note.lisp
@@ -39,6 +39,14 @@ a CL:FORMAT control string referencing the values contained in ARGS."
       (write-string (logevent-to-string evt) *notestream*)
     ))
 
+(defun s-note (msg &key (level :info) (subsystem :unknown) data)
+  "Emit a note of progress to the appropiate logging system
+MESSAGE-OR-FORMAT is either a simple string containing a message, or
+a CL:FORMAT control string referencing the values contained in ARGS."
+  (let* ((evt (logevent msg :level level :subsystem subsystem :data data)))
+      (write-string (logevent-to-string evt) *notestream*)
+    ))
+
 (eval-when (:load-toplevel)
   ;; hook, even if Actors isn't loaded...
   ;; If Actors are loaded later, they will respect the hook
@@ -47,4 +55,7 @@ a CL:FORMAT control string referencing the values contained in ARGS."
 
 (defun em-warn (message-or-format &rest args)
   "Like note but this is for warnings."
-  (apply #'%prefixed-note " WARN " message-or-format args))
+  (let* ((msg (apply #'format nil message-or-format args))
+        (evt (logevent msg :level :warn :subsystem :unknown)))
+    (write-string (logevent-to-string evt) *notestream*))
+  )

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -52,6 +52,7 @@
   (:export
    #:*notestream*
    #:note
+   #:s-note
    #:em-warn)
   (:export
    #:production-p


### PR DESCRIPTION
Use `alist` for internal logging events representation.
Depending on output write as JSON for automated processing or pretty print to the `stdout`.

As initial implementation, migrated `emotiq:note` to use logevent mechanism to mock current behavior

TODO: Export interface to publish structured log events.

Closes #431