### PR TITLE
Fix initial txid3

### DIFF
--- a/src/Cosi-BLS/new-transactions.lisp
+++ b/src/Cosi-BLS/new-transactions.lisp
@@ -1020,8 +1020,8 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
 
 (defun coinbase-transaction-input-p (transaction-input)
   (with-slots (tx-in-id tx-in-index) transaction-input
-    (and (equal tx-in-id *initial-coinbase-tx-in-id-value*)
-         (equal tx-in-index *initial-coinbase-tx-in-index-value*))))
+    (and (pbc= tx-in-id *initial-coinbase-tx-in-id-value*)
+         (= tx-in-index *initial-coinbase-tx-in-index-value*))))
 
 (defun make-coinbase-transaction-input ()
   (make-instance

--- a/src/Cosi-BLS/new-transactions.lisp
+++ b/src/Cosi-BLS/new-transactions.lisp
@@ -1000,9 +1000,20 @@ OBJECTS. Arg TYPE is implicitly quoted (not evaluated)."
 ;;; their normal function, so these values are arbitrary. These two ARE part
 ;;; of the hash of the transaction.
 
-(defvar *initial-coinbase-tx-in-id-value*
-  (make-instance 'hash:hash
-                 :val (bev (hex "0000000000000000000000000000000000000000000000000000000000000000"))))
+(defparameter *initial-coinbase-tx-in-id-value* nil)
+
+(defun zero-address ()
+  ; Form an arbitrary HASH/256 of any old seed, then copy the BEV into a new vector, then zap that vector with a FILL of zero. 
+  ; And then reconstruct the HASH/256 item with that modified BEV. (COPY-SEQ)
+  (let* ((h (hash:hash/256 :test))
+         (vec (vec-repr:bev-vec h))
+         (dum (copy-seq vec)))
+    (fill dum 0)
+    (setf (slot-value h 'hash::val) (vec-repr:bev dum))
+    h))
+
+(defun init-new-transactions ()
+  (setf *initial-coinbase-tx-in-id-value* (zero-address)))
 
 (defvar *initial-coinbase-tx-in-index-value*
   -1)

--- a/src/Cosi-BLS/package.lisp
+++ b/src/Cosi-BLS/package.lisp
@@ -242,7 +242,9 @@
    get-balance
 
    to-txid
-   find-tx))
+   find-tx
+
+   #:init-new-transactions))
 
 ;; from cosi-construction
 (defpackage :cosi-simgen

--- a/src/startup.lisp
+++ b/src/startup.lisp
@@ -25,6 +25,7 @@
 
 (defun main (&key etc-and-wallets how-started-message?)
   "Main loop for Emotiq daemon"
+  (cosi/proofs/newtx:init-new-transactions)
   (emotiq/random:init-random) ;; after calling this, (RANDOM 100) will return the same sequence of pseudo-random numbers on each test run 
   (when etc-and-wallets
     (setf (symbol-function 'emotiq/fs:etc/)


### PR DESCRIPTION
Closes #435 

In new-transactions.lisp, I found one EQUAL that I think should be PBC= and another that should simply be a numeric comparison (which I changed to =).
